### PR TITLE
Fix off-by-one sprite frame by advancing image_index at the start of the step.

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -1168,6 +1168,27 @@ void Runner_step(Runner* runner) {
         }
     }
 
+    // Advance image_index by image_speed for all active instances
+    int32_t animCount = (int32_t) arrlen(runner->instances);
+    repeat(animCount, i) {
+        Instance* inst = runner->instances[i];
+        if (!inst->active) continue;
+        if (0 > inst->spriteIndex) continue;
+
+        inst->imageIndex += inst->imageSpeed;
+
+        // Wrap image_index (matches HTML5 runner: manual subtract/add instead of using fmod)
+        Sprite* sprite = &runner->dataWin->sprt.sprites[inst->spriteIndex];
+        GMLReal frameCount = (GMLReal) sprite->textureCount;
+        if (inst->imageIndex >= frameCount) {
+            inst->imageIndex -= frameCount;
+            Runner_executeEvent(runner, inst, EVENT_OTHER, OTHER_ANIMATION_END);
+        } else if (0.0 > inst->imageIndex) {
+            inst->imageIndex += frameCount;
+            Runner_executeEvent(runner, inst, EVENT_OTHER, OTHER_ANIMATION_END);
+        }
+    }
+
     // Scroll backgrounds
     Runner_scrollBackgrounds(runner);
 
@@ -1275,27 +1296,6 @@ void Runner_step(Runner* runner) {
 
     // Update view following and clamping
     updateViews(runner);
-
-    // Advance image_index by image_speed for all active instances
-    int32_t animCount = (int32_t) arrlen(runner->instances);
-    repeat(animCount, i) {
-        Instance* inst = runner->instances[i];
-        if (!inst->active) continue;
-        if (0 > inst->spriteIndex) continue;
-
-        inst->imageIndex += inst->imageSpeed;
-
-        // Wrap image_index (matches HTML5 runner: manual subtract/add instead of using fmod)
-        Sprite* sprite = &runner->dataWin->sprt.sprites[inst->spriteIndex];
-        GMLReal frameCount = (GMLReal) sprite->textureCount;
-        if (inst->imageIndex >= frameCount) {
-            inst->imageIndex -= frameCount;
-            Runner_executeEvent(runner, inst, EVENT_OTHER, OTHER_ANIMATION_END);
-        } else if (0.0 > inst->imageIndex) {
-            inst->imageIndex += frameCount;
-            Runner_executeEvent(runner, inst, EVENT_OTHER, OTHER_ANIMATION_END);
-        }
-    }
 
     // Handle room transition
     if (runner->pendingRoom >= 0) {


### PR DESCRIPTION
**Fix off-by-one sprite frame by advancing image_index at the start of the step.**

The image_index was being advanced after the step events, causing sprites to display one frame ahead on the same step they were updated.

<img width="1284" height="576" alt="image" src="https://github.com/user-attachments/assets/410711ff-fd45-4b00-b5b7-09d539a3afa0" />
