### PR TITLE
Add macOS to supported platforms list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Of course, there are exceptions that break game compatibility altogether:
 ## Supported Platforms
 
 * Linux (GLFW, OpenGL)
+* macOS (GLFW, OpenGL)
 * Windows (GLFW, OpenGL, MinGW)
 * PlayStation 2 (ps2sdk, gsKit)
 * Haiku (GLFW)


### PR DESCRIPTION
I can confirm that Butterscotch successfully builds and runs Undertale 1.08 on macOS 26.4 without any code changes. Built with glfw 3.4 installed with brew.

<img width="1172" height="517" alt="Screenshot 2026-04-18 at 12 12 42 PM" src="https://github.com/user-attachments/assets/c1a2435d-3a2d-44af-9350-9fbb5decc8d6" />
