### PR TITLE
GLFW: Implement window_set_caption

### DIFF
--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -457,6 +457,10 @@ static void characterCallback(GLFWwindow* window, unsigned int codepoint) {
     RunnerKeyboard_onCharacter(runner->keyboard, codepoint);
 }
 
+static void setGlfwWindowTitle(void* window, const char* title) {
+    glfwSetWindowTitle((GLFWwindow*) window, title);
+}
+
 void saveInputRecording() {
     // Save input recording if active, then free
     if (globalInputRecording != nullptr) {
@@ -676,6 +680,8 @@ int main(int argc, char* argv[]) {
     Runner* runner = Runner_create(dataWin, vm, renderer, (FileSystem*) glfwFileSystem, audioSystem);
     runner->debugMode = args.debug;
     runner->osType = args.osType;
+    runner->nativeWindow = window;
+    runner->setWindowTitle = setGlfwWindowTitle;
 
     // Set up input recording/playback (both can be active: playback then continue recording)
     if (args.playbackInputsPath != nullptr) {

--- a/src/runner.h
+++ b/src/runner.h
@@ -258,6 +258,8 @@ typedef struct Runner {
     bool drawBackgroundColor;
     bool shouldExit;
     bool debugMode;
+    void* nativeWindow;
+    void (*setWindowTitle)(void* window, const char* title);
     TileLayerMapEntry* tileLayerMap; // stb_ds hashmap: depth -> tile layer state
     RuntimeLayer* runtimeLayers; // stb_ds array, index-parallel to currentRoom->layers for parsed entries; dynamic entries appended
     uint32_t nextLayerId;        // counter for IDs of layers/elements created at runtime

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -3123,7 +3123,6 @@ STUB_RETURN_ZERO(joystick_check_button)
 // Window stubs
 STUB_RETURN_ZERO(window_get_fullscreen)
 STUB_RETURN_UNDEFINED(window_set_fullscreen)
-STUB_RETURN_UNDEFINED(window_set_caption)
 STUB_RETURN_UNDEFINED(window_set_size)
 STUB_RETURN_UNDEFINED(window_center)
 static RValue builtinWindowGetWidth(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
@@ -3132,6 +3131,20 @@ static RValue builtinWindowGetWidth(VMContext* ctx, MAYBE_UNUSED RValue* args, M
 
 static RValue builtinWindowGetHeight(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
     return RValue_makeReal((GMLReal) ctx->dataWin->gen8.defaultWindowHeight);
+}
+
+static RValue builtinWindowSetCaption(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
+    char* val = RValue_toString(args[0]);
+    char windowTitle[256];
+    snprintf(windowTitle, sizeof(windowTitle), "Butterscotch - %s", val);
+    free(val);
+
+    Runner* runner = (Runner*) ctx->runner;
+    if (runner->setWindowTitle && runner->nativeWindow) {
+        runner->setWindowTitle(runner->nativeWindow, windowTitle);
+    }
+
+    return RValue_makeUndefined();
 }
 
 // ===[ Game State Functions ]===
@@ -6301,7 +6314,7 @@ void VMBuiltins_registerAll(VMContext* ctx) {
     // Window
     VM_registerBuiltin(ctx, "window_get_fullscreen", builtin_window_get_fullscreen);
     VM_registerBuiltin(ctx, "window_set_fullscreen", builtin_window_set_fullscreen);
-    VM_registerBuiltin(ctx, "window_set_caption", builtin_window_set_caption);
+    VM_registerBuiltin(ctx, "window_set_caption", builtinWindowSetCaption);
     VM_registerBuiltin(ctx, "window_set_size", builtin_window_set_size);
     VM_registerBuiltin(ctx, "window_center", builtin_window_center);
     VM_registerBuiltin(ctx, "window_get_width", builtinWindowGetWidth);

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -3137,13 +3137,14 @@ static RValue builtinWindowSetCaption(VMContext* ctx, MAYBE_UNUSED RValue* args,
     char* val = RValue_toString(args[0]);
     char windowTitle[256];
     snprintf(windowTitle, sizeof(windowTitle), "Butterscotch - %s", val);
-    free(val);
 
     Runner* runner = (Runner*) ctx->runner;
     if (runner->setWindowTitle && runner->nativeWindow) {
         runner->setWindowTitle(runner->nativeWindow, windowTitle);
+        printf("GL: Window title set to: %s\n", val);
     }
-
+    
+    free(val);
     return RValue_makeUndefined();
 }
 


### PR DESCRIPTION
Implements [window_set_caption](https://manual.gamemaker.io/lts/en/GameMaker_Language/GML_Reference/Cameras_And_Display/The_Game_Window/window_set_caption.htm) for GLFW, which allows games to set a custom window title. Notably used throughout Deltarune Chapter 1. 

Tested in the SURVEY_PROGRAM build of Deltarune:
<img width="752" height="624" alt="Screenshot 2026-04-18 at 4 01 20 PM" src="https://github.com/user-attachments/assets/bc464db4-73b9-488c-8deb-c51be32e4433" />
<img width="752" height="624" alt="Screenshot 2026-04-18 at 4 02 18 PM" src="https://github.com/user-attachments/assets/ae03e5ca-b390-414a-a6d5-1391d304f056" />
