### PR TITLE
Audio: Support compressed audio

### DIFF
--- a/src/glfw/ma_audio_system.c
+++ b/src/glfw/ma_audio_system.c
@@ -197,8 +197,9 @@ static int32_t maPlaySound(AudioSystem* audio, int32_t soundIndex, int32_t prior
         slot->ownsDecoder = false;
     } else {
         bool isEmbedded = (sound->flags & 0x01) != 0;
+        bool isCompressed = (sound->flags & 0x02) != 0;
 
-        if (isEmbedded) {
+        if (isEmbedded || isCompressed) {
             // Embedded audio: decode from AUDO chunk memory
             if (0 > sound->audioFile || (uint32_t) sound->audioFile >= ma->base.audioGroups[sound->audioGroup]->audo.count) {
                 fprintf(stderr, "Audio: Invalid audio file index %d for sound '%s'\n", sound->audioFile, sound->name);

--- a/src/ps2/ps2_audio_system.c
+++ b/src/ps2/ps2_audio_system.c
@@ -721,17 +721,18 @@ static int32_t ps2PlaySound(AudioSystem* audio, int32_t soundIndex, int32_t prio
     float sondPitch = (sond->pitch == 0) ? 1.0f : (float) sond->pitch / 256.0f;
 
     bool isEmbedded = (sond->flags & 0x01) != 0;
+    bool isCompressed = (sond->flags & 0x01) != 0;
 
     // Some sounds are mis-flagged as embedded when they are actually long tracks (example: "spamton_neo_mix_ex_wip" in DELTARUNE Chapter 2)
     // Decoding them into the LRU cache would blow EE RAM, so force them through the streaming path when the decoded PCM would exceed the cache budget.
     Ps2AudoEntry* audoForSize = &ps2->audoEntries[sond->audoIndex];
     uint32_t decodedPcmBytes = audoForSize->dataSize * 2 * (uint32_t) sizeof(int16_t);
-    if (isEmbedded && decodedPcmBytes > PS2_SFX_CACHE_MAX_BYTES) {
+    if ((isEmbedded || isCompressed) && decodedPcmBytes > PS2_SFX_CACHE_MAX_BYTES) {
         fprintf(stderr, "PS2AudioSystem: Sound %" PRId32 " (audo %d) is flagged embedded but would need %" PRIu32 " bytes of PCM! Streaming instead...\n", soundIndex, sond->audoIndex, decodedPcmBytes);
         isEmbedded = false;
     }
 
-    if (!isEmbedded) {
+    if (!isEmbedded || !isCompressed) {
         // ===[ Streaming music path ]===
         // Find a free music stream slot
         Ps2MusicStream* stream = nullptr;

--- a/src/ps2/ps2_audio_system.c
+++ b/src/ps2/ps2_audio_system.c
@@ -721,7 +721,7 @@ static int32_t ps2PlaySound(AudioSystem* audio, int32_t soundIndex, int32_t prio
     float sondPitch = (sond->pitch == 0) ? 1.0f : (float) sond->pitch / 256.0f;
 
     bool isEmbedded = (sond->flags & 0x01) != 0;
-    bool isCompressed = (sond->flags & 0x01) != 0;
+    bool isCompressed = (sond->flags & 0x02) != 0;
 
     // Some sounds are mis-flagged as embedded when they are actually long tracks (example: "spamton_neo_mix_ex_wip" in DELTARUNE Chapter 2)
     // Decoding them into the LRU cache would blow EE RAM, so force them through the streaming path when the decoded PCM would exceed the cache budget.


### PR DESCRIPTION
Adds support for embedded compressed audio.

This allows the sound effect for Omega Flowey's flamethrower attack in Undertale to play successfully. Because the sound effect (`snd_flameloop.ogg`) did not have the isEmbedded flag, Butterscotch would try and fail to load an external sound of the same name. However, `snd_flameloop.ogg` is an embedded sound, and needs to be treated as such in order be played.

Save file for testing: [Save.zip](https://github.com/user-attachments/files/26871317/Save.zip)
