### PR TITLE
VM: Implement window_has_focus and instance_nearest

### DIFF
--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -476,6 +476,10 @@ static void setGlfwWindowTitle(void* window, const char* title) {
     glfwSetWindowTitle((GLFWwindow*) window, title);
 }
 
+static bool getGlfwWindowFocus(void* window) {
+    return glfwGetWindowAttrib((GLFWwindow*) window, GLFW_FOCUSED) != 0;
+}
+
 void saveInputRecording() {
     // Save input recording if active, then free
     if (globalInputRecording != nullptr) {
@@ -720,6 +724,7 @@ int main(int argc, char* argv[]) {
     runner->osType = args.osType;
     runner->nativeWindow = window;
     runner->setWindowTitle = setGlfwWindowTitle;
+    runner->windowHasFocus = getGlfwWindowFocus;
 
     // Set up input recording/playback (both can be active: playback then continue recording)
     if (args.playbackInputsPath != nullptr) {

--- a/src/runner.c
+++ b/src/runner.c
@@ -454,7 +454,7 @@ static int compareDrawableDepth(const void* a, const void* b) {
 }
 
 static void fireDrawSubtype(Runner* runner, Drawable* drawables, int32_t drawableCount, int32_t subtype) {
-    int32_t slot = EventSlotMap_lookup(&runner->eventSlotMap, eventType, eventSubtype);
+    int32_t slot = EventSlotMap_lookup(&runner->eventSlotMap, EVENT_DRAW, subtype);
     if (slot == -1) return;
 
     repeat(drawableCount, i) {

--- a/src/runner.h
+++ b/src/runner.h
@@ -335,6 +335,7 @@ typedef struct Runner {
     bool debugMode;
     void* nativeWindow;
     void (*setWindowTitle)(void* window, const char* title);
+    bool (*windowHasFocus)(void* window);
     TileLayerMapEntry* tileLayerMap; // stb_ds hashmap: depth -> tile layer state
     RuntimeLayer* runtimeLayers; // stb_ds array, index-parallel to currentRoom->layers for parsed entries; dynamic entries appended
     uint32_t nextLayerId;        // counter for IDs of layers/elements created at runtime

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -4055,6 +4055,20 @@ static RValue builtinWindowGetHeight(VMContext* ctx, MAYBE_UNUSED RValue* args, 
     return RValue_makeReal((GMLReal) ctx->dataWin->gen8.defaultWindowHeight);
 }
 
+static RValue builtinWindowHasFocus(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
+    Runner* runner = (Runner*) ctx->runner;
+    // Always return true when not on GLFW
+    if (runner == NULL || runner->nativeWindow == NULL) {
+        return RValue_makeBool(true);
+    }
+
+    if (runner->windowHasFocus) {
+        return RValue_makeBool(runner->windowHasFocus(runner->nativeWindow));
+    }
+
+    return RValue_makeBool(true);
+}
+
 static RValue builtinWindowSetCaption(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
     char* val = RValue_toString(args[0]);
     char windowTitle[256];
@@ -8053,6 +8067,7 @@ void VMBuiltins_registerAll(VMContext* ctx) {
     VM_registerBuiltin(ctx, "window_center", builtin_window_center);
     VM_registerBuiltin(ctx, "window_get_width", builtinWindowGetWidth);
     VM_registerBuiltin(ctx, "window_get_height", builtinWindowGetHeight);
+    VM_registerBuiltin(ctx, "window_has_focus", builtinWindowHasFocus);
 
     // Game
     VM_registerBuiltin(ctx, "game_restart", builtinGameRestart);

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -4055,20 +4055,6 @@ static RValue builtinWindowGetHeight(VMContext* ctx, MAYBE_UNUSED RValue* args, 
     return RValue_makeReal((GMLReal) ctx->dataWin->gen8.defaultWindowHeight);
 }
 
-static RValue builtinWindowHasFocus(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
-    Runner* runner = (Runner*) ctx->runner;
-    // Always return true when not on GLFW
-    if (runner == NULL || runner->nativeWindow == NULL) {
-        return RValue_makeBool(true);
-    }
-
-    if (runner->windowHasFocus) {
-        return RValue_makeBool(runner->windowHasFocus(runner->nativeWindow));
-    }
-
-    return RValue_makeBool(true);
-}
-
 static RValue builtinWindowSetCaption(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
     char* val = RValue_toString(args[0]);
     char windowTitle[256];
@@ -4082,6 +4068,20 @@ static RValue builtinWindowSetCaption(VMContext* ctx, MAYBE_UNUSED RValue* args,
     
     free(val);
     return RValue_makeUndefined();
+}
+
+static RValue builtinWindowHasFocus(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
+    Runner* runner = (Runner*) ctx->runner;
+    // Always return true when not on GLFW
+    if (runner == NULL || runner->nativeWindow == NULL) {
+        return RValue_makeBool(true);
+    }
+
+    if (runner->windowHasFocus) {
+        return RValue_makeBool(runner->windowHasFocus(runner->nativeWindow));
+    }
+
+    return RValue_makeBool(true);
 }
 
 // ===[ Game State Functions ]===

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -4131,6 +4131,33 @@ static RValue builtinInstanceFind(VMContext* ctx, RValue* args, int32_t argCount
     return RValue_makeReal((GMLReal) resultId);
 }
 
+static RValue builtinInstanceNearest(VMContext* ctx, RValue* args, int32_t argCount) {
+    if (3 > argCount) return RValue_makeReal(INSTANCE_NOONE);
+    Runner* runner = (Runner*) ctx->runner;
+    GMLReal x = RValue_toReal(args[0]);
+    GMLReal y = RValue_toReal(args[1]);
+    GMLReal bestDistSq = 0.0;
+    int32_t objectIndex = RValue_toInt32(args[2]);
+    int32_t resultId = INSTANCE_NOONE;
+    int32_t snapBase = Runner_pushInstancesOfObject(runner, objectIndex);
+    int32_t snapEnd  = (int32_t) arrlen(runner->instanceSnapshots);
+    for (int32_t i = snapBase; snapEnd > i; i++) {
+        Instance* inst = runner->instanceSnapshots[i];
+        if (!inst->active) continue;
+
+        GMLReal dx = inst->x - x;
+        GMLReal dy = inst->y - y;
+        GMLReal distSq = dx * dx + dy * dy;
+
+        if (resultId == INSTANCE_NOONE || distSq < bestDistSq) {
+            resultId = inst->instanceId;
+            bestDistSq = distSq;
+        }
+    }
+    Runner_popInstanceSnapshot(runner, snapBase);
+    return RValue_makeReal((GMLReal) resultId);
+}
+
 static RValue builtinInstanceExists(VMContext* ctx, RValue* args, int32_t argCount) {
     if (1 > argCount) return RValue_makeBool(false);
     Runner* runner = (Runner*) ctx->runner;
@@ -8079,6 +8106,7 @@ void VMBuiltins_registerAll(VMContext* ctx) {
     VM_registerBuiltin(ctx, "instance_exists", builtinInstanceExists);
     VM_registerBuiltin(ctx, "instance_number", builtinInstanceNumber);
     VM_registerBuiltin(ctx, "instance_find", builtinInstanceFind);
+    VM_registerBuiltin(ctx, "instance_nearest", builtinInstanceNearest);
     VM_registerBuiltin(ctx, "instance_destroy", builtinInstanceDestroy);
     if(!isGMS2) {
         VM_registerBuiltin(ctx, "instance_create", builtinInstanceCreate);

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -4073,7 +4073,7 @@ static RValue builtinWindowSetCaption(VMContext* ctx, MAYBE_UNUSED RValue* args,
 static RValue builtinWindowHasFocus(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
     Runner* runner = (Runner*) ctx->runner;
     // Always return true when not on GLFW
-    if (runner == NULL || runner->nativeWindow == NULL) {
+    if (runner == nullptr || runner->nativeWindow == nullptr) {
         return RValue_makeBool(true);
     }
 


### PR DESCRIPTION
Implements [window_has_focus](https://manual.gamemaker.io/lts/en/index.htm#t=GameMaker_Language%2FGML_Reference%2FCameras_And_Display%2FThe_Game_Window%2Fwindow_has_focus.htm) and [instance_nearest](https://manual.gamemaker.io/lts/en/GameMaker_Language/GML_Reference/Asset_Management/Instances/instance_nearest.htm). Properly checks focus status on GLFW. On other platforms (PS2), focus status is always set to `true`.

Allows Minit: Fun Racer to be playable. Loading saves is still broken.