### PR TITLE
Fix internal inconsistency in binary read/write endianness

### DIFF
--- a/src/binary_reader.c
+++ b/src/binary_reader.c
@@ -1,4 +1,5 @@
 #include "binary_reader.h"
+#include "binary_utils.h"
 #include "utils.h"
 
 #include <stdlib.h>
@@ -49,45 +50,45 @@ uint8_t BinaryReader_readUint8(BinaryReader* reader) {
 }
 
 int16_t BinaryReader_readInt16(BinaryReader* reader) {
-    int16_t value;
-    readCheck(reader, &value, 2);
-    return value;
+    uint8_t bytes[2];
+    readCheck(reader, bytes, sizeof(bytes));
+    return (int16_t) BinaryUtils_readUint16(bytes);
 }
 
 uint16_t BinaryReader_readUint16(BinaryReader* reader) {
-    uint16_t value;
-    readCheck(reader, &value, 2);
-    return value;
+    uint8_t bytes[2];
+    readCheck(reader, bytes, sizeof(bytes));
+    return BinaryUtils_readUint16(bytes);
 }
 
 int32_t BinaryReader_readInt32(BinaryReader* reader) {
-    int32_t value;
-    readCheck(reader, &value, 4);
-    return value;
+    uint8_t bytes[4];
+    readCheck(reader, bytes, sizeof(bytes));
+    return (int32_t) BinaryUtils_readUint32(bytes);
 }
 
 uint32_t BinaryReader_readUint32(BinaryReader* reader) {
-    uint32_t value;
-    readCheck(reader, &value, 4);
-    return value;
+    uint8_t bytes[4];
+    readCheck(reader, bytes, sizeof(bytes));
+    return BinaryUtils_readUint32(bytes);
 }
 
 float BinaryReader_readFloat32(BinaryReader* reader) {
-    float value;
-    readCheck(reader, &value, 4);
-    return value;
+    uint8_t bytes[4];
+    readCheck(reader, bytes, sizeof(bytes));
+    return BinaryUtils_readFloat32(bytes);
 }
 
 uint64_t BinaryReader_readUint64(BinaryReader* reader) {
-    uint64_t value;
-    readCheck(reader, &value, 8);
-    return value;
+    uint8_t bytes[8];
+    readCheck(reader, bytes, sizeof(bytes));
+    return BinaryUtils_readUint64(bytes);
 }
 
 int64_t BinaryReader_readInt64(BinaryReader* reader) {
-    int64_t value;
-    readCheck(reader, &value, 8);
-    return value;
+    uint8_t bytes[8];
+    readCheck(reader, bytes, sizeof(bytes));
+    return (int64_t) BinaryUtils_readUint64(bytes);
 }
 
 bool BinaryReader_readBool32(BinaryReader* reader) {

--- a/src/binary_utils.h
+++ b/src/binary_utils.h
@@ -27,26 +27,34 @@ static inline int32_t BinaryUtils_readInt32(const uint8_t* data) {
     return (int32_t) BinaryUtils_readUint32(data);
 }
 
+static inline uint64_t BinaryUtils_readUint64(const uint8_t* data) {
+    return (uint64_t) data[0] | ((uint64_t) data[1] << 8) | ((uint64_t) data[2] << 16) | ((uint64_t) data[3] << 24) |
+           ((uint64_t) data[4] << 32) | ((uint64_t) data[5] << 40) | ((uint64_t) data[6] << 48) | ((uint64_t) data[7] << 56);
+}
+
 static inline int64_t BinaryUtils_readInt64(const uint8_t* data) {
-    uint64_t val = (uint64_t) data[0] | ((uint64_t) data[1] << 8) | ((uint64_t) data[2] << 16) | ((uint64_t) data[3] << 24) |
-                   ((uint64_t) data[4] << 32) | ((uint64_t) data[5] << 40) | ((uint64_t) data[6] << 48) | ((uint64_t) data[7] << 56);
-    return (int64_t) val;
+    return (int64_t) BinaryUtils_readUint64(data);
 }
 
 static inline float BinaryUtils_readFloat32(const uint8_t* data) {
+    uint32_t bits = BinaryUtils_readUint32(data);
     float val;
-    memcpy(&val, data, 4);
+    memcpy(&val, &bits, 4);
     return val;
 }
 
 static inline double BinaryUtils_readFloat64(const uint8_t* data) {
+    uint64_t bits = BinaryUtils_readUint64(data);
     double val;
-    memcpy(&val, data, 8);
+    memcpy(&val, &bits, 8);
     return val;
 }
 
 static inline void BinaryUtils_writeUint32(uint8_t* data, uint32_t val) {
-    memcpy(data, &val, 4);
+    data[0] = (uint8_t) (val & 0xFF);
+    data[1] = (uint8_t) ((val >> 8) & 0xFF);
+    data[2] = (uint8_t) ((val >> 16) & 0xFF);
+    data[3] = (uint8_t) ((val >> 24) & 0xFF);
 }
 
 // ===[ Aligned reads ]===
@@ -54,9 +62,7 @@ static inline void BinaryUtils_writeUint32(uint8_t* data, uint32_t val) {
 // Used on the VM dispatch hot path (bytecode instruction / operand fetch) where the bytecode buffer is guaranteed 4-byte aligned.
 
 static inline uint32_t BinaryUtils_readUint32Aligned(const uint8_t* data) {
-    uint32_t val;
-    memcpy(&val, __builtin_assume_aligned(data, 4), 4);
-    return val;
+    return BinaryUtils_readUint32(data);
 }
 
 static inline int32_t BinaryUtils_readInt32Aligned(const uint8_t* data) {
@@ -64,21 +70,13 @@ static inline int32_t BinaryUtils_readInt32Aligned(const uint8_t* data) {
 }
 
 static inline int64_t BinaryUtils_readInt64Aligned(const uint8_t* data) {
-    // Note: GML bytecode places 8-byte extra-data at instruction + 4, so it is only 4-aligned.
-    int64_t val;
-    memcpy(&val, __builtin_assume_aligned(data, 4), 8);
-    return val;
+    return BinaryUtils_readInt64(data);
 }
 
 static inline float BinaryUtils_readFloat32Aligned(const uint8_t* data) {
-    float val;
-    memcpy(&val, __builtin_assume_aligned(data, 4), 4);
-    return val;
+    return BinaryUtils_readFloat32(data);
 }
 
 static inline double BinaryUtils_readFloat64Aligned(const uint8_t* data) {
-    // Note: GML bytecode places 8-byte extra-data at instruction + 4, so it is only 4-aligned.
-    double val;
-    memcpy(&val, __builtin_assume_aligned(data, 4), 8);
-    return val;
+    return BinaryUtils_readFloat64(data);
 }


### PR DESCRIPTION
Fixes an internal inconsistency where some binary paths were explicitly little-endian while others relied on native-endian reads/writes.