### PR TITLE
Fix serialization of quotes in ini files

### DIFF
--- a/src/ini.c
+++ b/src/ini.c
@@ -59,6 +59,16 @@ static const char* skipWhitespace(const char* p) {
     return p;
 }
 
+static char* normalizeValue(char* value) {
+    TextUtils_trimTrailingWhitespace(value);
+    size_t length = strlen(value);
+    if (length >= 2 && value[0] == '"' && value[length - 1] == '"') {
+        value[length - 1] = '\0';
+        return safeStrdup(value + 1);
+    }
+    return safeStrdup(value);
+}
+
 // ===[ Lifecycle ]===
 
 IniFile* Ini_parse(const char* text) {
@@ -115,14 +125,15 @@ IniFile* Ini_parse(const char* text) {
                 char* value = equals + 1;
                 TextUtils_trimTrailingWhitespace(key);
                 value = (char*) skipWhitespace(value);
+                char* normalizedValue = normalizeValue(value);
 
                 // Check if key already exists - overwrite if so
                 int existingIndex = findKeyIndex(currentSection, key);
                 if (existingIndex >= 0) {
                     free(currentSection->values[existingIndex]);
-                    currentSection->values[existingIndex] = safeStrdup(value);
+                    currentSection->values[existingIndex] = normalizedValue;
                 } else {
-                    addKeyValue(currentSection, key, value);
+                    addKeyValue(currentSection, key, normalizedValue);
                 }
             }
             // Silently skip key=value lines outside any section (matching GML behavior)
@@ -301,8 +312,10 @@ char* Ini_serialize(const IniFile* ini, size_t initialCapacity) {
             memcpy(buffer + length, key, keyLen);
             length += keyLen;
             buffer[length++] = '=';
+            buffer[length++] = '"';
             memcpy(buffer + length, value, valueLen);
             length += valueLen;
+            buffer[length++] = '"';
             buffer[length++] = '\n';
         }
     }

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -3564,6 +3564,14 @@ static RValue builtinIniReadString(VMContext* ctx, RValue* args, int32_t argCoun
 
     const char* value = Ini_getString(runner->currentIni, section, key);
     if (value != nullptr) {
+        // Old versions of Butterscotch didn't write quoted INI values
+        // This can likely be removed in the future, as GMS never does this(?)
+        if (value[0] == '"' && value[strlen(value) - 1] == '"') {
+            size_t valueLen = strlen(value);
+            char* buffer = safeStrdup(value + 1);
+            buffer[valueLen - 2] = '\0';
+            return RValue_makeOwnedString(buffer);
+        }
         return RValue_makeOwnedString(safeStrdup(value));
     }
 
@@ -3571,6 +3579,8 @@ static RValue builtinIniReadString(VMContext* ctx, RValue* args, int32_t argCoun
     if (args[2].type == RVALUE_STRING && args[2].string != nullptr) {
         return RValue_makeOwnedString(safeStrdup(args[2].string));
     }
+
+    free(value);
     char* str = RValue_toString(args[2]);
     return RValue_makeOwnedString(str);
 }

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -3564,14 +3564,6 @@ static RValue builtinIniReadString(VMContext* ctx, RValue* args, int32_t argCoun
 
     const char* value = Ini_getString(runner->currentIni, section, key);
     if (value != nullptr) {
-        // Old versions of Butterscotch didn't write quoted INI values
-        // This can likely be removed in the future, as GMS never does this(?)
-        if (value[0] == '"' && value[strlen(value) - 1] == '"') {
-            size_t valueLen = strlen(value);
-            char* buffer = safeStrdup(value + 1);
-            buffer[valueLen - 2] = '\0';
-            return RValue_makeOwnedString(buffer);
-        }
         return RValue_makeOwnedString(safeStrdup(value));
     }
 
@@ -3579,8 +3571,6 @@ static RValue builtinIniReadString(VMContext* ctx, RValue* args, int32_t argCoun
     if (args[2].type == RVALUE_STRING && args[2].string != nullptr) {
         return RValue_makeOwnedString(safeStrdup(args[2].string));
     }
-
-    free(value);
     char* str = RValue_toString(args[2]);
     return RValue_makeOwnedString(str);
 }


### PR DESCRIPTION
Butterscotch improperly reads quotes around ini values as a part of the value, causing a number of issues. This fixes the serialization to account for these quotes when reading and writing ini files.

Fixes issues in UNDERTALE and DELTARUNE when importing saves from the official runner. Fixes text in AM2R.

| Before    | After |
| -------- | ------- |
|  <img width="752" height="624" alt="UT_Before" src="https://github.com/user-attachments/assets/36aa05a4-1ac7-4369-9cb6-977c065bcc70" /> | <img width="752" height="624" alt="UT_After" src="https://github.com/user-attachments/assets/e234c5aa-7a73-496a-9e60-8af70ce2f5cf" />  |
| <img width="432" height="384" alt="am2r_Before" src="https://github.com/user-attachments/assets/d0788a03-e672-4f01-89b8-e5b59dc78af5" /> | <img width="432" height="384" alt="am2r_After" src="https://github.com/user-attachments/assets/f80066ac-c546-4b31-a7b0-b0b4bc5d01cf" /> |
