### PR TITLE
Audio/GLFW: Free audio groups before termination

### DIFF
--- a/src/glfw/ma_audio_system.c
+++ b/src/glfw/ma_audio_system.c
@@ -119,6 +119,14 @@ static void maDestroy(AudioSystem* audio) {
         }
     }
 
+    // Free loaded audio groups. The main data.win is owned by the caller, so skip index 0.
+    if (arrlen(ma->base.audioGroups) > 1) {
+        for (int32_t i = 1; i < (int32_t) arrlen(ma->base.audioGroups); i++) {
+            DataWin_free(ma->base.audioGroups[i]);
+        }
+    }
+    arrfree(ma->base.audioGroups);
+
     ma_engine_uninit(&ma->engine);
     free(ma);
 }


### PR DESCRIPTION
Very minor change. `leaks` on macOS reports unfreed audio groups as a memory leak. To prevent this, audio groups are now freed before termination.

Changes observed in SURVEY_PROGRAM.