### PR TITLE
ps2: Refactor overlay into separate file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ build/
 build_ps2/
 .gitignore
 .cache
-
+CMakeUserPresets.json
+.devcontainer/

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -535,7 +535,7 @@ int main(int argc, char* argv[]) {
 
     // ===[ Main Loop ]===
     bool debugOverlayStartEnabled = JsonReader_getBool(JsonReader_getObject(configRoot, "debugOverlayEnabled"));
-    PS2Overlay_setState(debugOverlayStartEnabled ? STATS_ENABLED : STATS_DISABLED, runner);
+    PS2Overlay_setDebugOverlayState(debugOverlayStartEnabled ? STATS_ENABLED : STATS_DISABLED, runner);
     uint16_t prevOverlayPadButtons = 0xFFFF;
 
     while (!runner->shouldExit) {
@@ -598,7 +598,7 @@ int main(int argc, char* argv[]) {
         }
 
         if (RunnerKeyboard_checkPressed(runner->keyboard, VK_F12)) {
-            PS2Overlay_incrementState(runner);
+            PS2Overlay_toggleDebugOverlay(runner);
         }
 
         // Reset global interact state because I HATE when I get stuck while moving through rooms
@@ -661,7 +661,7 @@ int main(int argc, char* argv[]) {
         float audioTime = (float) audioDuration / (float) (kBUSCLK / 1000);
 
         // ===[ Debug Overlay ]===
-        PS2Overlay_drawStats(renderer, runner, tickTime, stepTime, drawTime, audioTime, speedCapRemoved);
+        PS2Overlay_drawDebugOverlay(renderer, runner, tickTime, stepTime, drawTime, audioTime, speedCapRemoved);
 
         // Execute draw queue and flip buffers
         gsKit_queue_exec(gsGlobal);

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -6,7 +6,6 @@
 #include <dmaKit.h>
 #include <gsKit.h>
 #include <gsToolkit.h>
-#include <gsFontM.h>
 #include <libpad.h>
 #include <libmc.h>
 #include <libkbd.h>
@@ -29,6 +28,7 @@
 #include "stb_ds.h"
 #include "utils.h"
 #include "../profiler.h"
+#include "ps2/ps2_overlay.h"
 
 #ifdef GPROF_PROFILING
 #include <ps2prof.h>
@@ -231,180 +231,6 @@ static unsigned int hidUsageToAsciiChar(uint8_t hid, bool shift) {
     }
 }
 
-// ===[ Loading Screen ]===
-
-// Maximum number of chunk stats we track (24 chunks in data.win, but only some have interesting counts)
-#define MAX_CHUNK_STATS 24
-
-typedef struct {
-    char label[16];
-    uint32_t count;
-} ChunkStat;
-
-typedef struct {
-    GSGLOBAL* gsGlobal;
-    GSFONTM* gsFontM;
-    ChunkStat stats[MAX_CHUNK_STATS];
-    int statCount;
-} LoadingScreenState;
-
-// Draws the bottom-left credits text (shared between status screen and loading screen)
-static void drawCreditsText(GSGLOBAL* gs, GSFONTM* fontm) {
-    u64 darkGray = GS_SETREG_RGBAQ(0x70, 0x70, 0x70, 0x80, 0x00);
-    float creditsScale = 0.4f;
-    float lineHeight = 26.0f * creditsScale;
-    float creditsY = 448.0f - 10.0f - lineHeight * 2.0f;
-
-    char versionText[128];
-    snprintf(versionText, sizeof(versionText), "Butterscotch (%s) [%s]", BUTTERSCOTCH_COMMIT_HASH, BUTTERSCOTCH_COMMIT_DATE);
-    gsKit_fontm_print_scaled(gs, fontm, 10.0f, creditsY, 1, creditsScale, darkGray, versionText);
-    gsKit_fontm_print_scaled(gs, fontm, 10.0f, creditsY + lineHeight, 1, creditsScale, darkGray, "Created by MrPowerGamerBR (https://mrpowergamerbr.com/)");
-}
-
-// Draws a simple status screen with "Butterscotch" title, optional game name, and a status message (no progress bar)
-// gameName can be nullptr if the game name is not yet known
-// Begins a status screen: clears, draws title + optional game name, leaves center align active
-static void beginStatusScreen(GSGLOBAL* gs, GSFONTM* fontm, const char* gameName) {
-    gsKit_clear(gs, GS_SETREG_RGBAQ(0x00, 0x00, 0x00, 0x80, 0x00));
-
-    u64 title = GS_SETREG_RGBAQ(0x5E, 0x54, 0x92, 0x80, 0x00);
-    u64 gray = GS_SETREG_RGBAQ(0xAA, 0xAA, 0xAA, 0x80, 0x00);
-
-    fontm->Align = GSKIT_FALIGN_CENTER;
-    gsKit_fontm_print_scaled(gs, fontm, 320.0f, 180.0f, 1, 0.8f, title, "Butterscotch");
-    if (gameName) {
-        gsKit_fontm_print_scaled(gs, fontm, 320.0f, 210.0f, 1, 0.5f, gray, gameName);
-    }
-}
-
-// Ends a status screen: draws credits, resets align, flips
-static void endStatusScreen(GSGLOBAL* gs, GSFONTM* fontm) {
-    fontm->Align = GSKIT_FALIGN_LEFT;
-    drawCreditsText(gs, fontm);
-    gsKit_queue_exec(gs);
-    gsKit_sync_flip(gs);
-}
-
-// Draws chunk item counts in the top-left corner (if any stats have been recorded)
-static void drawChunkStats(GSGLOBAL* gs, GSFONTM* fontm, LoadingScreenState* loadingState) {
-    if (!loadingState || loadingState->statCount == 0)
-        return;
-
-    u64 gray = GS_SETREG_RGBAQ(0xAA, 0xAA, 0xAA, 0x80, 0x00);
-    fontm->Align = GSKIT_FALIGN_LEFT;
-    float statsY = 10.0f;
-    float statsScale = 0.35f;
-    float statsLineHeight = 14.0f;
-    char statLine[32];
-
-    repeat(loadingState->statCount, i) {
-        snprintf(statLine, sizeof(statLine), "%d %s", loadingState->stats[i].count, loadingState->stats[i].label);
-        gsKit_fontm_print_scaled(gs, fontm, 10.0f, statsY, 1, statsScale, gray, statLine);
-        statsY += statsLineHeight;
-    }
-}
-
-static void drawStatusScreen(GSGLOBAL* gs, GSFONTM* fontm, const char* gameName, const char* statusText, LoadingScreenState* loadingState) {
-    beginStatusScreen(gs, fontm, gameName);
-    u64 gray = GS_SETREG_RGBAQ(0xAA, 0xAA, 0xAA, 0x80, 0x00);
-    gsKit_fontm_print_scaled(gs, fontm, 320.0f, 300.0f, 1, 0.5f, gray, statusText);
-    drawChunkStats(gs, fontm, loadingState);
-    endStatusScreen(gs, fontm);
-}
-
-static void loadingScreenCallback(const char* chunkName, int chunkIndex, int totalChunks, DataWin* dataWin, void* userData) {
-    LoadingScreenState* state = (LoadingScreenState*) userData;
-    GSGLOBAL* gs = state->gsGlobal;
-    GSFONTM* fontm = state->gsFontM;
-
-    const char* gameName = dataWin->gen8.displayName ? dataWin->gen8.displayName : "Unknown Game";
-    beginStatusScreen(gs, fontm, gameName);
-
-    // Loading bar
-    u64 white = GS_SETREG_RGBAQ(0xFF, 0xFF, 0xFF, 0x80, 0x00);
-    u64 barBg = GS_SETREG_RGBAQ(0x40, 0x40, 0x40, 0x80, 0x00);
-    u64 barFg = GS_SETREG_RGBAQ(0xFF, 0xCC, 0x00, 0x80, 0x00); // Butterscotch yellow
-
-    float barX = 120.0f;
-    float barY = 300.0f;
-    float barW = 400.0f;
-    float barH = 20.0f;
-    float progress = (float) (chunkIndex + 1) / (float) totalChunks;
-
-    // Bar background (dark gray)
-    gsKit_prim_sprite(gs, barX, barY, barX + barW, barY + barH, 1, barBg);
-
-    // Bar fill (butterscotch yellow)
-    float fillW = barW * progress;
-    if (fillW > 1.0f) {
-        gsKit_prim_sprite(gs, barX, barY, barX + fillW, barY + barH, 1, barFg);
-    }
-
-    // Enable alpha blending so the font text doesn't have a black box behind it
-    gs->PrimAlphaEnable = GS_SETTING_ON;
-    gsKit_set_primalpha(gs, GS_SETREG_ALPHA(0, 1, 0, 1, 0), 0);
-
-    // Percentage text centered on the bar
-    char percentText[8];
-    snprintf(percentText, sizeof(percentText), "%d%%", (int) (progress * 100));
-    gsKit_fontm_print_scaled(gs, fontm, 320.0f, barY + 4.5f, 1, 0.4f, white, percentText);
-
-    // Chunk name text below the bar
-    char statusText[32];
-    snprintf(statusText, sizeof(statusText), "Loading %.4s... (%d/%d)", chunkName, chunkIndex + 1, totalChunks);
-    gsKit_fontm_print_scaled(gs, fontm, 320.0f, barY + barH + 10.0f, 1, 0.5f, white, statusText);
-
-    // Memory usage below the status text
-    u64 gray = GS_SETREG_RGBAQ(0xAA, 0xAA, 0xAA, 0x80, 0x00);
-    void* heapTop = sbrk(0);
-    int32_t usedBytes = (int32_t) (uintptr_t) heapTop;
-    char memText[48];
-    snprintf(memText, sizeof(memText), "Memory: %.1f/%.1f MB", (double) (usedBytes / (1024.0f * 1024.0f)), (double) (MAX_MEMORY_BYTES / (1024.0f * 1024.0f)));
-    gsKit_fontm_print_scaled(gs, fontm, 320.0f, barY + barH + 30.0f, 1, 0.4f, gray, memText);
-
-    // Record item counts for already-parsed chunks (callback fires before parsing, so we scan all counts each time and add any newly non-zero ones in the order they appear)
-    typedef struct { uint32_t* countPtr; const char* label; } CountSource;
-    CountSource sources[] = {
-        { &dataWin->sond.count, "sounds" },
-        { &dataWin->sprt.count, "sprites" },
-        { &dataWin->bgnd.count, "backgrounds" },
-        { &dataWin->font.count, "fonts" },
-        { &dataWin->objt.count, "objects" },
-        { &dataWin->room.count, "rooms" },
-        { &dataWin->code.count, "code entries" },
-        { &dataWin->txtr.count, "textures" },
-    };
-
-    // sizeof(sources) = size of the ENTIRE array
-    // So, if we divide the size of the ENTIRE array by the size of a SINGLE entry, we get the number of entries
-    int arrayLength = sizeof(sources) / sizeof(CountSource);
-
-    repeat(arrayLength, i) {
-        if (*sources[i].countPtr == 0)
-            continue;
-
-        // Check if we already recorded this label
-        bool found = false;
-        forEach(CountSource, stat, sources, state->statCount) {
-            if (strcmp(stat->label, sources[i].label) == 0) {
-                found = true;
-                break;
-            }
-        }
-
-        if (!found && MAX_CHUNK_STATS > state->statCount) {
-            ChunkStat* stat = &state->stats[state->statCount++];
-            snprintf(stat->label, sizeof(stat->label), "%s", sources[i].label);
-            stat->count = *sources[i].countPtr;
-        }
-    }
-
-    drawChunkStats(gs, fontm, state);
-
-    gs->PrimAlphaEnable = GS_SETTING_OFF;
-
-    endStatusScreen(gs, fontm);
-}
 
 int main(int argc, char* argv[]) {
     SifInitRpc(0);
@@ -453,13 +279,11 @@ int main(int argc, char* argv[]) {
     // Use ONE SHOT mode
     gsKit_mode_switch(gsGlobal, GS_ONESHOT);
 
-    // ===[ Initialize FONTM (ROM font) for debug overlay ]===
-    GSFONTM* gsFontM = gsKit_init_fontm();
-    gsKit_fontm_upload(gsGlobal, gsFontM);
-    gsFontM->Spacing = 0.95f;
+    // ===[ Initialize debug overlay ]===
+    PS2Overlay_init(gsGlobal, MAX_MEMORY_BYTES, heapCeilingBytes);
 
     // ===[ Initialize Controller ]===
-    drawStatusScreen(gsGlobal, gsFontM, nullptr, "Initializing controller...", nullptr);
+    PS2Overlay_drawStatusScreen(nullptr, "Initializing controller...", false);
 
     int ret;
     ret = SifExecModuleBuffer(freesio2_irx, size_freesio2_irx, 0, nullptr, nullptr);
@@ -525,8 +349,7 @@ int main(int argc, char* argv[]) {
 #endif
 
     // Wait for pad to be ready
-    drawStatusScreen(gsGlobal, gsFontM, nullptr, "Waiting for controller...", nullptr);
-
+    PS2Overlay_drawStatusScreen(nullptr, "Waiting for controller...", false);
     int padState;
     do {
         padState = padGetState(0, 0);
@@ -534,14 +357,8 @@ int main(int argc, char* argv[]) {
 
     printf("Controller initialized\n");
 
-    // ===[ Loading Screen State ]===
-    LoadingScreenState loadingState = {
-        .gsGlobal = gsGlobal,
-        .gsFontM = gsFontM,
-    };
-
     // ===[ Load CONFIG.JSN ]===
-    drawStatusScreen(gsGlobal, gsFontM, nullptr, "Loading CONFIG.JSN...", nullptr);
+    PS2Overlay_drawStatusScreen(nullptr, "Loading CONFIG.JSN...", false);
 
     char* configJsonPath = PS2Utils_createDevicePath("CONFIG.JSN");
     FILE* configFile = fopen(configJsonPath, "rb");
@@ -563,7 +380,7 @@ int main(int argc, char* argv[]) {
     free(configJsonPath);
 
     if (configRoot == nullptr) {
-        drawStatusScreen(gsGlobal, gsFontM, nullptr, "CONFIG.JSN invalid or not found!", nullptr);
+        PS2Overlay_drawStatusScreen(nullptr, "CONFIG.JSN invalid or not found!", false);
         while (true) {}
     }
 
@@ -577,7 +394,7 @@ int main(int argc, char* argv[]) {
     }
 
     // ===[ Parse data.win ]===
-    drawStatusScreen(gsGlobal, gsFontM, nullptr, "Loading data.win...", nullptr);
+    PS2Overlay_drawStatusScreen(nullptr, "Loading data.win...", false);
 
     DataWin* dataWin = DataWin_parse(
         dataWinPath,
@@ -608,8 +425,8 @@ int main(int argc, char* argv[]) {
             .skipLoadingPreciseMasksForNonPreciseSprites = true,
             .lazyLoadRooms = lazyLoadRooms,
             .eagerlyLoadedRooms = eagerRooms,
-            .progressCallback = loadingScreenCallback,
-            .progressCallbackUserData = &loadingState,
+            .progressCallback = PS2Overlay_statusScreenCallback,
+            .progressCallbackUserData = PS2Overlay_getCallbackData(),
         }
     );
     free(dataWinPath);
@@ -626,7 +443,7 @@ int main(int argc, char* argv[]) {
     if (!bytecodeVersionSupported) {
         char errorText[128];
         snprintf(errorText, sizeof(errorText), "Unsupported bytecode version %u!", dataWin->gen8.bytecodeVersion);
-        drawStatusScreen(gsGlobal, gsFontM, dataWin->gen8.displayName, errorText, &loadingState);
+        PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, errorText, true);
         while (true) {}
     }
 
@@ -639,30 +456,29 @@ int main(int argc, char* argv[]) {
 
     FileSystem* fileSystem = Ps2FileSystem_create(configRoot, dataWin->gen8.displayName);
     if (fileSystem == nullptr) {
-        drawStatusScreen(gsGlobal, gsFontM, dataWin->gen8.displayName, "CONFIG.JSN is missing the fileSystem configuration!", &loadingState);
+        PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "CONFIG.JSN is missing the fileSystem configuration!", true);
         while (true) {}
     }
 
-    drawStatusScreen(gsGlobal, gsFontM, dataWin->gen8.displayName, "Creating VM...", &loadingState);
+    PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "Creating VM...", true);
 
     VMContext* vm = VM_create(dataWin);
 
     // ===[ Initialize Renderer ]===
-    drawStatusScreen(gsGlobal, gsFontM, dataWin->gen8.displayName, "Initializing renderer...", &loadingState);
+    PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "Initializing renderer...", true);
 
     Renderer* renderer = GsRenderer_create(gsGlobal);
 
     // ===[ Initialize Audio System ]===
 #ifdef ENABLE_PS2_AUDIO
-    drawStatusScreen(gsGlobal, gsFontM, dataWin->gen8.displayName, "Initializing audio...", &loadingState);
+    PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "Initializing audio...", true);
     Ps2AudioSystem* ps2Audio = Ps2AudioSystem_create();
     AudioSystem* audioSystem = (AudioSystem*) ps2Audio;
 #else
     AudioSystem* audioSystem = (AudioSystem*) NoopAudioSystem_create();
 #endif
 
-    drawStatusScreen(gsGlobal, gsFontM, dataWin->gen8.displayName, "Creating runner...", &loadingState);
-
+    PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "Creating runner...", true);
     Runner* runner = Runner_create(dataWin, vm, renderer, fileSystem, audioSystem);
 
     // Parse disabledObjects from CONFIG.JSN
@@ -691,10 +507,10 @@ int main(int argc, char* argv[]) {
         printf("Memory after VM and runner creation: used=%d bytes (%.1f KB), total=%d bytes (%.1f KB), free=%d bytes (%.1f KB)\n", usedBytes, (double) (usedBytes / 1024.0f), MAX_MEMORY_BYTES, (double) (MAX_MEMORY_BYTES / 1024.0f), freeBytes, (double) (freeBytes / 1024.0f));
     }
 
-    drawStatusScreen(gsGlobal, gsFontM, dataWin->gen8.displayName, "Initializing first room...", &loadingState);
+    PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "Initializing first room...", true);
     Runner_initFirstRoom(runner);
 
-    drawStatusScreen(gsGlobal, gsFontM, dataWin->gen8.displayName, "Reticulating splines...", &loadingState);
+    PS2Overlay_drawStatusScreen(dataWin->gen8.displayName, "Reticulating splines...", true);
 
     // ===[ gprof Profiler Setup ]===
 #ifdef GPROF_PROFILING
@@ -719,13 +535,9 @@ int main(int argc, char* argv[]) {
 
     // ===[ Main Loop ]===
     bool debugOverlayStartEnabled = JsonReader_getBool(JsonReader_getObject(configRoot, "debugOverlayEnabled"));
-    int debugOverlayState = debugOverlayStartEnabled ? 0 : 2;
+    PS2Overlay_setState(debugOverlayStartEnabled ? STATS_ENABLED : STATS_DISABLED, runner);
     uint16_t prevOverlayPadButtons = 0xFFFF;
-    int profilerFramesInWindow = 0;
-    static const int PROFILER_WINDOW_FRAMES = 60;
-#ifdef ENABLE_VM_GML_PROFILER
-    char profilerOverlayText[4096];
-#endif
+
     while (!runner->shouldExit) {
         u64 frameStartTime = GetTimerSystemTime();
         // ===[ Poll Controller (always poll every vsync) ]===
@@ -786,12 +598,7 @@ int main(int argc, char* argv[]) {
         }
 
         if (RunnerKeyboard_checkPressed(runner->keyboard, VK_F12)) {
-            debugOverlayState = (debugOverlayState + 1) % 3;
-#ifdef ENABLE_VM_GML_PROFILER
-            Profiler_setEnabled(&vm->profiler, debugOverlayState == 1);
-            profilerFramesInWindow = 0;
-            profilerOverlayText[0] = '\0';
-#endif
+            PS2Overlay_incrementState(runner);
         }
 
         // Reset global interact state because I HATE when I get stuck while moving through rooms
@@ -854,55 +661,7 @@ int main(int argc, char* argv[]) {
         float audioTime = (float) audioDuration / (float) (kBUSCLK / 1000);
 
         // ===[ Debug Overlay ]===
-        if (debugOverlayState == 0 || debugOverlayState == 1) {
-            u64 debugColor = GS_SETREG_RGBAQ(0xFF, 0xFF, 0xFF, 0x80, 0x00);
-            char debugText[512];
-            uint32_t vramFreeBytes = GS_VRAM_SIZE - gsGlobal->CurrentPointer;
-
-            // Count atlases loaded in VRAM and EE RAM cache
-            GsRenderer* gsRenderer = (GsRenderer*) renderer;
-            uint32_t vramAtlasCount = 0;
-            uint32_t eeramAtlasCount = 0;
-            repeat(gsRenderer->atlasCount, ai) {
-                if (gsRenderer->atlasToChunk[ai] >= 0) vramAtlasCount++;
-                if (gsRenderer->eeCacheEntries[ai].atlasId >= 0) eeramAtlasCount++;
-            }
-
-            int freeBytes = heapCeilingBytes - mallinfo().uordblks;
-
-            const char* roomName = runner->currentRoom != nullptr && runner->currentRoom->name != nullptr ? runner->currentRoom->name : "?";
-
-            const char* thrashIndicator = "";
-            if (gsRenderer->chunksNeededThisFrame > gsRenderer->chunkCount) {
-                thrashIndicator = gsRenderer->diskLoadsThisFrame > 0 ? " [RAM+DISK THRASHING]" : " [RAM THRASHING]";
-            } else if (gsRenderer->diskLoadsThisFrame > 0) {
-                thrashIndicator = " [DISK LOAD]";
-            }
-
-            snprintf(debugText, sizeof(debugText), "Room: %s\nTick: %.2fms\nStep: %.2fms\nDraw: %.2fms\nAudio: %.2fms\nFree: %d bytes\nVRAM Free: %lu bytes\nRoom Speed: %u%s\nAtlas: (%u, %u, %u) [%u/%u]%s\nInstances: %d\nStructs: %d", roomName, (double) tickTime, (double) stepTime, (double) drawTime, (double) audioTime, freeBytes, (unsigned long) vramFreeBytes, roomSpeed, speedCapRemoved ? " [UNCAPPED]" : "", vramAtlasCount, eeramAtlasCount, gsRenderer->atlasCount, gsRenderer->chunksNeededThisFrame, gsRenderer->chunkCount, thrashIndicator, (int) arrlen(runner->instances), (int) arrlen(runner->structInstances));
-            gsKit_fontm_print_scaled(gsGlobal, gsFontM, 10.0f, 10.0f, 10, 0.6f, debugColor, debugText);
-
-            if (debugOverlayState == 1) {
-                float profilerY = 10.0f + (15.6f * 10.0f) + 6.0f;
-
-#ifdef ENABLE_VM_GML_PROFILER
-                profilerFramesInWindow++;
-                if (profilerFramesInWindow >= PROFILER_WINDOW_FRAMES) {
-                    char* profilerReport = Profiler_createReport(vm->profiler, 25, profilerFramesInWindow);
-                    if (profilerReport != nullptr) {
-                        snprintf(profilerOverlayText, sizeof(profilerOverlayText), "%s", profilerReport);
-                        free(profilerReport);
-                    }
-                    Profiler_reset(vm->profiler);
-                    profilerFramesInWindow = 0;
-                }
-                const char* profilerDisplay = profilerOverlayText[0] != '\0' ? profilerOverlayText : "GML Profiler (collecting...)";
-                gsKit_fontm_print_scaled(gsGlobal, gsFontM, 10.0f, profilerY, 10, 0.35f, debugColor, profilerDisplay);
-#else
-                gsKit_fontm_print_scaled(gsGlobal, gsFontM, 10.0f, profilerY, 10, 0.35f, debugColor, "Butterscotch GML Profiler is disabled on this build :(");
-#endif
-            }
-        }
+        PS2Overlay_drawStats(renderer, runner, tickTime, stepTime, drawTime, audioTime, speedCapRemoved);
 
         // Execute draw queue and flip buffers
         gsKit_queue_exec(gsGlobal);
@@ -937,6 +696,7 @@ int main(int argc, char* argv[]) {
     runner->audioSystem = nullptr;
     renderer->vtable->destroy(renderer);
     DataWin_free(dataWin);
+    PS2Overlay_deinit();
 
     return 0;
 }

--- a/src/ps2/ps2_overlay.c
+++ b/src/ps2/ps2_overlay.c
@@ -1,0 +1,287 @@
+#include "ps2/ps2_overlay.h"
+
+#include <malloc.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "ps2/ps2_utils.h"
+
+// ===[ Loading Screen ]===
+
+static const int PROFILER_WINDOW_FRAMES = 60;
+static bool gPS2OverlayInitialized = false;
+static PS2Overlay gOverlay = { 0 };
+
+// Draws chunk item counts in the top-left corner (if any stats have been recorded)
+static void drawChunkStats(GSGLOBAL* gs, GSFONTM* fontm, LoadingScreenState* loadingState) {
+    if (!loadingState || loadingState->statCount == 0)
+        return;
+
+    u64 gray = GS_SETREG_RGBAQ(0xAA, 0xAA, 0xAA, 0x80, 0x00);
+    fontm->Align = GSKIT_FALIGN_LEFT;
+    float statsY = 10.0f;
+    float statsScale = 0.35f;
+    float statsLineHeight = 14.0f;
+    char statLine[32];
+
+    repeat(loadingState->statCount, i) {
+        snprintf(statLine, sizeof(statLine), "%d %s", loadingState->stats[i].count, loadingState->stats[i].label);
+        gsKit_fontm_print_scaled(gs, fontm, 10.0f, statsY, 1, statsScale, gray, statLine);
+        statsY += statsLineHeight;
+    }
+}
+
+// Draws a simple status screen with "Butterscotch" title, optional game name, and a status message (no progress bar)
+// gameName can be nullptr if the game name is not yet known
+// Begins a status screen: clears, draws title + optional game name, leaves center align active
+static void beginStatusScreen(GSGLOBAL* gs, GSFONTM* fontm, const char* gameName) {
+    gsKit_clear(gs, GS_SETREG_RGBAQ(0x00, 0x00, 0x00, 0x80, 0x00));
+
+    u64 title = GS_SETREG_RGBAQ(0x5E, 0x54, 0x92, 0x80, 0x00);
+    u64 gray = GS_SETREG_RGBAQ(0xAA, 0xAA, 0xAA, 0x80, 0x00);
+
+    fontm->Align = GSKIT_FALIGN_CENTER;
+    gsKit_fontm_print_scaled(gs, fontm, 320.0f, 180.0f, 1, 0.8f, title, "Butterscotch");
+    if (gameName) {
+        gsKit_fontm_print_scaled(gs, fontm, 320.0f, 210.0f, 1, 0.5f, gray, gameName);
+    }
+}
+
+// Draws the bottom-left credits text (shared between status screen and loading screen)
+static void drawCreditsText(GSGLOBAL* gs, GSFONTM* fontm) {
+    u64 darkGray = GS_SETREG_RGBAQ(0x70, 0x70, 0x70, 0x80, 0x00);
+    float creditsScale = 0.4f;
+    float lineHeight = 26.0f * creditsScale;
+    float creditsY = 448.0f - 10.0f - lineHeight * 2.0f;
+
+    char versionText[128];
+    snprintf(versionText, sizeof(versionText), "Butterscotch (%s) [%s]", BUTTERSCOTCH_COMMIT_HASH, BUTTERSCOTCH_COMMIT_DATE);
+    gsKit_fontm_print_scaled(gs, fontm, 10.0f, creditsY, 1, creditsScale, darkGray, versionText);
+    gsKit_fontm_print_scaled(gs, fontm, 10.0f, creditsY + lineHeight, 1, creditsScale, darkGray, "Created by MrPowerGamerBR (https://mrpowergamerbr.com/)");
+}
+
+// Ends a status screen: draws credits, resets align, flips
+static void endStatusScreen(GSGLOBAL* gs, GSFONTM* fontm) {
+    fontm->Align = GSKIT_FALIGN_LEFT;
+    drawCreditsText(gs, fontm);
+    gsKit_queue_exec(gs);
+    gsKit_sync_flip(gs);
+}
+
+void PS2Overlay_init(GSGLOBAL* gsGlobal, int memorySize, int heapCeiling) {
+    if (gPS2OverlayInitialized) return;
+
+    gOverlay.gsGlobal = gsGlobal;
+    gOverlay.memorySize = memorySize;
+    gOverlay.heapCeiling = heapCeiling;
+    gOverlay.state = STATS_DISABLED;
+    gOverlay.profilerFramesInWindow = 0;
+
+    gOverlay.gsFontm = gsKit_init_fontm();
+    gsKit_fontm_upload(gOverlay.gsGlobal, gOverlay.gsFontm);
+    gOverlay.gsFontm->Spacing = 0.95f;
+
+    gPS2OverlayInitialized = true;
+}
+
+void PS2Overlay_deinit() {
+    if (!gPS2OverlayInitialized) return;
+
+    gsKit_free_fontm(gOverlay.gsGlobal, gOverlay.gsFontm);
+
+    memset(&gOverlay, 0, sizeof(gOverlay));
+    gPS2OverlayInitialized = false;
+}
+
+StatsOverlayState PS2Overlay_getState() {
+    if (!gPS2OverlayInitialized) return STATS_DISABLED;
+    return gOverlay.state;
+}
+
+void PS2Overlay_setState(StatsOverlayState state, Runner* runner) {
+    if (!gPS2OverlayInitialized) return;
+    gOverlay.state = state;
+
+#ifdef ENABLE_VM_GML_PROFILER
+    Profiler_setEnabled(&runner->vmContext->profiler, PS2Overlay_getState() == STATS_ENABLED_WITH_PROFILER);
+    gOverlay.profilerFramesInWindow = 0;
+    gOverlay.profilerOverlayText[0] = '\0';
+#endif
+}
+
+void PS2Overlay_incrementState(Runner* runner) {
+    if (!gPS2OverlayInitialized) return;
+    gOverlay.state = (gOverlay.state + 1) % STATS_MAX;
+
+#ifdef ENABLE_VM_GML_PROFILER
+    Profiler_setEnabled(&runner->vmContext->profiler, PS2Overlay_getState() == STATS_ENABLED_WITH_PROFILER);
+    gOverlay.profilerFramesInWindow = 0;
+    gOverlay.profilerOverlayText[0] = '\0';
+#endif
+}
+
+PS2Overlay* PS2Overlay_getCallbackData() {
+    return &gOverlay;
+}
+
+void PS2Overlay_statusScreenCallback(const char* chunkName, int chunkIndex, int totalChunks, DataWin* dataWin, void* userData) {
+    if (!gPS2OverlayInitialized) return;
+
+    PS2Overlay* data = (PS2Overlay*) userData;
+    LoadingScreenState* state = &data->loadingState;
+    GSGLOBAL* gs = data->gsGlobal;
+    GSFONTM* fontm = data->gsFontm;
+
+    const char* gameName = dataWin->gen8.displayName ? dataWin->gen8.displayName : "Unknown Game";
+    beginStatusScreen(gs, fontm, gameName);
+
+    // Loading bar
+    u64 white = GS_SETREG_RGBAQ(0xFF, 0xFF, 0xFF, 0x80, 0x00);
+    u64 barBg = GS_SETREG_RGBAQ(0x40, 0x40, 0x40, 0x80, 0x00);
+    u64 barFg = GS_SETREG_RGBAQ(0xFF, 0xCC, 0x00, 0x80, 0x00); // Butterscotch yellow
+
+    float barX = 120.0f;
+    float barY = 300.0f;
+    float barW = 400.0f;
+    float barH = 20.0f;
+    float progress = (float) (chunkIndex + 1) / (float) totalChunks;
+
+    // Bar background (dark gray)
+    gsKit_prim_sprite(gs, barX, barY, barX + barW, barY + barH, 1, barBg);
+
+    // Bar fill (butterscotch yellow)
+    float fillW = barW * progress;
+    if (fillW > 1.0f) {
+        gsKit_prim_sprite(gs, barX, barY, barX + fillW, barY + barH, 1, barFg);
+    }
+
+    // Enable alpha blending so the font text doesn't have a black box behind it
+    gs->PrimAlphaEnable = GS_SETTING_ON;
+    gsKit_set_primalpha(gs, GS_SETREG_ALPHA(0, 1, 0, 1, 0), 0);
+
+    // Percentage text centered on the bar
+    char percentText[8];
+    snprintf(percentText, sizeof(percentText), "%d%%", (int) (progress * 100));
+    gsKit_fontm_print_scaled(gs, fontm, 320.0f, barY + 4.5f, 1, 0.4f, white, percentText);
+
+    // Chunk name text below the bar
+    char statusText[32];
+    snprintf(statusText, sizeof(statusText), "Loading %.4s... (%d/%d)", chunkName, chunkIndex + 1, totalChunks);
+    gsKit_fontm_print_scaled(gs, fontm, 320.0f, barY + barH + 10.0f, 1, 0.5f, white, statusText);
+
+    // Memory usage below the status text
+    u64 gray = GS_SETREG_RGBAQ(0xAA, 0xAA, 0xAA, 0x80, 0x00);
+    void* heapTop = sbrk(0);
+    int32_t usedBytes = (int32_t) (uintptr_t) heapTop;
+    char memText[48];
+    snprintf(memText, sizeof(memText), "Memory: %.1f/%.1f MB", (double) (usedBytes / (1024.0f * 1024.0f)), (double) (gOverlay.memorySize / (1024.0f * 1024.0f)));
+    gsKit_fontm_print_scaled(gs, fontm, 320.0f, barY + barH + 30.0f, 1, 0.4f, gray, memText);
+
+    // Record item counts for already-parsed chunks (callback fires before parsing, so we scan all counts each time and add any newly non-zero ones in the order they appear)
+    typedef struct { uint32_t* countPtr; const char* label; } CountSource;
+    CountSource sources[] = {
+        { &dataWin->sond.count, "sounds" },
+        { &dataWin->sprt.count, "sprites" },
+        { &dataWin->bgnd.count, "backgrounds" },
+        { &dataWin->font.count, "fonts" },
+        { &dataWin->objt.count, "objects" },
+        { &dataWin->room.count, "rooms" },
+        { &dataWin->code.count, "code entries" },
+        { &dataWin->txtr.count, "textures" },
+    };
+
+    // sizeof(sources) = size of the ENTIRE array
+    // So, if we divide the size of the ENTIRE array by the size of a SINGLE entry, we get the number of entries
+    int arrayLength = sizeof(sources) / sizeof(CountSource);
+
+    repeat(arrayLength, i) {
+        if (*sources[i].countPtr == 0)
+            continue;
+
+        // Check if we already recorded this label
+        bool found = false;
+        forEach(CountSource, stat, sources, state->statCount) {
+            if (strcmp(stat->label, sources[i].label) == 0) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found && MAX_CHUNK_STATS > state->statCount) {
+            ChunkStat* stat = &state->stats[state->statCount++];
+            snprintf(stat->label, sizeof(stat->label), "%s", sources[i].label);
+            stat->count = *sources[i].countPtr;
+        }
+    }
+
+    drawChunkStats(gs, fontm, state);
+
+    gs->PrimAlphaEnable = GS_SETTING_OFF;
+
+    endStatusScreen(gs, fontm);
+}
+
+void PS2Overlay_drawStatusScreen(const char* gameName, const char* statusText, bool includeChunkStats) {
+    if (!gPS2OverlayInitialized) return;
+
+    beginStatusScreen(gOverlay.gsGlobal, gOverlay.gsFontm, gameName);
+    u64 gray = GS_SETREG_RGBAQ(0xAA, 0xAA, 0xAA, 0x80, 0x00);
+    gsKit_fontm_print_scaled(gOverlay.gsGlobal, gOverlay.gsFontm, 320.0f, 300.0f, 1, 0.5f, gray, statusText);
+    if (includeChunkStats) {
+        drawChunkStats(gOverlay.gsGlobal, gOverlay.gsFontm, &gOverlay.loadingState);
+    }
+    endStatusScreen(gOverlay.gsGlobal, gOverlay.gsFontm);
+}
+
+void PS2Overlay_drawStats(const Renderer* renderer, const Runner* runner, float tick, float step, float draw, float audio, bool speedCapRemoved) {
+    if (!gPS2OverlayInitialized) return;
+    if (gOverlay.state == STATS_DISABLED) return;
+
+    u64 debugColor = GS_SETREG_RGBAQ(0xFF, 0xFF, 0xFF, 0x80, 0x00);
+    char debugText[512];
+    uint32_t vramFreeBytes = GS_VRAM_SIZE - gOverlay.gsGlobal->CurrentPointer;
+
+    // Count atlases loaded in VRAM and EE RAM cache
+    const GsRenderer* gsRenderer = (GsRenderer*) renderer;
+    uint32_t vramAtlasCount = 0;
+    uint32_t eeramAtlasCount = 0;
+    repeat(gsRenderer->atlasCount, ai) {
+        if (gsRenderer->atlasToChunk[ai] >= 0) vramAtlasCount++;
+        if (gsRenderer->eeCacheEntries[ai].atlasId >= 0) eeramAtlasCount++;
+    }
+
+    int freeBytes = gOverlay.heapCeiling - mallinfo().uordblks;
+
+    const char* roomName = runner->currentRoom != nullptr && runner->currentRoom->name != nullptr ? runner->currentRoom->name : "?";
+
+    const char* thrashIndicator = "";
+    if (gsRenderer->chunksNeededThisFrame > gsRenderer->chunkCount) {
+        thrashIndicator = gsRenderer->diskLoadsThisFrame > 0 ? " [RAM+DISK THRASHING]" : " [RAM THRASHING]";
+    } else if (gsRenderer->diskLoadsThisFrame > 0) {
+        thrashIndicator = " [DISK LOAD]";
+    }
+
+    snprintf(debugText, sizeof(debugText), "Room: %s\nTick: %.2fms\nStep: %.2fms\nDraw: %.2fms\nAudio: %.2fms\nFree: %d bytes\nVRAM Free: %lu bytes\nRoom Speed: %u%s\nAtlas: (%u, %u, %u) [%u/%u]%s\nInstances: %d\nStructs: %d", roomName, (double) tick, (double) step, (double) draw, (double) audio, freeBytes, (unsigned long) vramFreeBytes, runner->currentRoom->speed, speedCapRemoved ? " [UNCAPPED]" : "", vramAtlasCount, eeramAtlasCount, gsRenderer->atlasCount, gsRenderer->chunksNeededThisFrame, gsRenderer->chunkCount, thrashIndicator, (int) arrlen(runner->instances), (int) arrlen(runner->structInstances));
+    gsKit_fontm_print_scaled(gOverlay.gsGlobal, gOverlay.gsFontm, 10.0f, 10.0f, 10, 0.6f, debugColor, debugText);
+
+    if (gOverlay.state == STATS_ENABLED_WITH_PROFILER) {
+        float profilerY = 10.0f + (15.6f * 10.0f) + 6.0f;
+
+#ifdef ENABLE_VM_GML_PROFILER
+        gOverlay.profilerFramesInWindow++;
+        if (gOverlay.profilerFramesInWindow >= PROFILER_WINDOW_FRAMES) {
+            char* profilerReport = Profiler_createReport(runner->vmContext->profiler, 25, gOverlay.profilerFramesInWindow);
+            if (profilerReport != nullptr) {
+                snprintf(gOverlay.profilerOverlayText, sizeof(gOverlay.profilerOverlayText), "%s", profilerReport);
+                free(profilerReport);
+            }
+            Profiler_reset(runner->vmContext->profiler);
+            gOverlay.profilerFramesInWindow = 0;
+        }
+        const char* profilerDisplay = gOverlay.profilerOverlayText[0] != '\0' ? gOverlay.profilerOverlayText : "GML Profiler (collecting...)";
+        gsKit_fontm_print_scaled(gOverlay.gsGlobal, gOverlay.gsFontm, 10.0f, profilerY, 10, 0.35f, debugColor, profilerDisplay);
+#else
+        gsKit_fontm_print_scaled(gOverlay.gsGlobal, gOverlay.gsFontm, 10.0f, profilerY, 10, 0.35f, debugColor, "Butterscotch GML Profiler is disabled on this build :(");
+#endif
+    }
+}

--- a/src/ps2/ps2_overlay.c
+++ b/src/ps2/ps2_overlay.c
@@ -93,28 +93,28 @@ void PS2Overlay_deinit() {
     gPS2OverlayInitialized = false;
 }
 
-StatsOverlayState PS2Overlay_getState() {
+DebugOverlayState PS2Overlay_getDebugOverlayState() {
     if (!gPS2OverlayInitialized) return STATS_DISABLED;
     return gOverlay.state;
 }
 
-void PS2Overlay_setState(StatsOverlayState state, Runner* runner) {
+void PS2Overlay_setDebugOverlayState(DebugOverlayState state, Runner* runner) {
     if (!gPS2OverlayInitialized) return;
     gOverlay.state = state;
 
 #ifdef ENABLE_VM_GML_PROFILER
-    Profiler_setEnabled(&runner->vmContext->profiler, PS2Overlay_getState() == STATS_ENABLED_WITH_PROFILER);
+    Profiler_setEnabled(&runner->vmContext->profiler, PS2Overlay_getDebugOverlayState() == STATS_ENABLED_WITH_PROFILER);
     gOverlay.profilerFramesInWindow = 0;
     gOverlay.profilerOverlayText[0] = '\0';
 #endif
 }
 
-void PS2Overlay_incrementState(Runner* runner) {
+void PS2Overlay_toggleDebugOverlay(Runner* runner) {
     if (!gPS2OverlayInitialized) return;
     gOverlay.state = (gOverlay.state + 1) % STATS_MAX;
 
 #ifdef ENABLE_VM_GML_PROFILER
-    Profiler_setEnabled(&runner->vmContext->profiler, PS2Overlay_getState() == STATS_ENABLED_WITH_PROFILER);
+    Profiler_setEnabled(&runner->vmContext->profiler, PS2Overlay_getDebugOverlayState() == STATS_ENABLED_WITH_PROFILER);
     gOverlay.profilerFramesInWindow = 0;
     gOverlay.profilerOverlayText[0] = '\0';
 #endif
@@ -233,7 +233,7 @@ void PS2Overlay_drawStatusScreen(const char* gameName, const char* statusText, b
     endStatusScreen(gOverlay.gsGlobal, gOverlay.gsFontm);
 }
 
-void PS2Overlay_drawStats(const Renderer* renderer, const Runner* runner, float tick, float step, float draw, float audio, bool speedCapRemoved) {
+void PS2Overlay_drawDebugOverlay(const Renderer* renderer, const Runner* runner, float tick, float step, float draw, float audio, bool speedCapRemoved) {
     if (!gPS2OverlayInitialized) return;
     if (gOverlay.state == STATS_DISABLED) return;
 

--- a/src/ps2/ps2_overlay.h
+++ b/src/ps2/ps2_overlay.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <gsKit.h>
+#include <gsToolkit.h>
+
+#include "ps2/gs_renderer.h"
+#include "runner.h"
+#include "profiler.h"
+
+// Maximum number of chunk stats we track (24 chunks in data.win, but only some have interesting counts)
+#define MAX_CHUNK_STATS 24
+
+typedef struct {
+    char label[16];
+    uint32_t count;
+} ChunkStat;
+
+typedef struct {
+    ChunkStat stats[MAX_CHUNK_STATS];
+    int statCount;
+} LoadingScreenState;
+
+typedef enum {
+    STATS_ENABLED = 0,
+    STATS_ENABLED_WITH_PROFILER = 1,
+    STATS_DISABLED = 2,
+    STATS_MAX
+} StatsOverlayState;
+
+typedef struct {
+    StatsOverlayState state;
+    GSGLOBAL* gsGlobal;
+    GSFONTM* gsFontm;
+    int memorySize;
+    int heapCeiling;
+    int profilerFramesInWindow;
+    LoadingScreenState loadingState;
+#ifdef ENABLE_VM_GML_PROFILER
+    char profilerOverlayText[4096];
+#endif
+} PS2Overlay;
+
+// Note that the caller is expected to own the `gsGlobal` object.
+void PS2Overlay_init(GSGLOBAL* gsGlobal, int memorySize, int heapCeiling);
+void PS2Overlay_deinit();
+
+StatsOverlayState PS2Overlay_getState();
+void PS2Overlay_setState(StatsOverlayState state, Runner* runner);
+void PS2Overlay_incrementState(Runner* runner);
+
+PS2Overlay* PS2Overlay_getCallbackData();
+void PS2Overlay_statusScreenCallback(const char* chunkName, int chunkIndex, int totalChunks, DataWin* dataWin, void* userData);
+
+void PS2Overlay_drawStatusScreen(const char* gameName, const char* statusText, bool includeChunkStats);
+void PS2Overlay_drawStats(const Renderer* renderer, const Runner* runner, float tick, float step, float draw, float audio, bool speedCapRemoved);

--- a/src/ps2/ps2_overlay.h
+++ b/src/ps2/ps2_overlay.h
@@ -25,10 +25,10 @@ typedef enum {
     STATS_ENABLED_WITH_PROFILER = 1,
     STATS_DISABLED = 2,
     STATS_MAX
-} StatsOverlayState;
+} DebugOverlayState;
 
 typedef struct {
-    StatsOverlayState state;
+    DebugOverlayState state;
     GSGLOBAL* gsGlobal;
     GSFONTM* gsFontm;
     int memorySize;
@@ -44,12 +44,12 @@ typedef struct {
 void PS2Overlay_init(GSGLOBAL* gsGlobal, int memorySize, int heapCeiling);
 void PS2Overlay_deinit();
 
-StatsOverlayState PS2Overlay_getState();
-void PS2Overlay_setState(StatsOverlayState state, Runner* runner);
-void PS2Overlay_incrementState(Runner* runner);
+DebugOverlayState PS2Overlay_getDebugOverlayState();
+void PS2Overlay_setDebugOverlayState(DebugOverlayState state, Runner* runner);
+void PS2Overlay_toggleDebugOverlay(Runner* runner);
 
 PS2Overlay* PS2Overlay_getCallbackData();
 void PS2Overlay_statusScreenCallback(const char* chunkName, int chunkIndex, int totalChunks, DataWin* dataWin, void* userData);
 
 void PS2Overlay_drawStatusScreen(const char* gameName, const char* statusText, bool includeChunkStats);
-void PS2Overlay_drawStats(const Renderer* renderer, const Runner* runner, float tick, float step, float draw, float audio, bool speedCapRemoved);
+void PS2Overlay_drawDebugOverlay(const Renderer* renderer, const Runner* runner, float tick, float step, float draw, float audio, bool speedCapRemoved);


### PR DESCRIPTION
This is a quick and dirty refactor to move the PS2 debug overlay/status screen code into a separate file.

Rationale:

- It was difficult to modify the overlay code previously because it was intertwined with the main function.
- The refactored code should be easier to read, although it isn't a completely clean interface.
- It's now much easier to add extra overlays in the future; for example, an overlay that draws whenever the game is writing to memory card.

Verified that the updated code runs on PCSX2 with and without `ENABLE_VM_GML_PROFILING`.