### PR TITLE
fix: handle (ignore) UTF-8 BOM in JsonReader_parse

### DIFF
--- a/src/json_reader.c
+++ b/src/json_reader.c
@@ -351,9 +351,14 @@ static JsonValue* parseValue(JsonParser* parser) {
 JsonValue* JsonReader_parse(const char* json) {
     if (json == nullptr) return nullptr;
 
+    size_t pos = 0;
+    if (memcmp(json, "\xEF\xBB\xBF", 3) == 0) {
+        pos = 3;
+    }
+
     JsonParser parser = {
         .input = json,
-        .position = 0,
+        .position = pos,
         .length = strlen(json),
     };
 


### PR DESCRIPTION
fix crash when trying to load Teiarruma's deltarune chapter 4 translation:
<img width="906" height="294" alt="image" src="https://github.com/user-attachments/assets/b77b3086-1327-43e7-9ad2-961edb967b74" />
(image by kalleu11)