### PR TITLE
Skip draw while room change pending

### DIFF
--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -1167,6 +1167,7 @@ int main(int argc, char* argv[]) {
         }
 
         glfwSwapBuffers(window);
+        Runner_handlePendingRoomChange(runner);
 
         // Limit frame rate to room speed (skip in headless mode for max speed!!)
         if (!args.headless && runner->currentRoom->speed > 0) {

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -907,6 +907,7 @@ int main(int argc, char* argv[]) {
         // Execute draw queue and flip buffers
         gsKit_queue_exec(gsGlobal);
         gsKit_sync_flip(gsGlobal);
+        Runner_handlePendingRoomChange(runner);
 
         // Busy-wait until enough time has elapsed for this frame if needed
         if (!speedCapRemoved && roomSpeed > 0) {

--- a/src/runner.c
+++ b/src/runner.c
@@ -889,6 +889,8 @@ void Runner_computeViewDisplayScale(Runner* runner, int32_t gameW, int32_t gameH
 }
 
 void Runner_drawViews(Runner* runner, int32_t gameW, int32_t gameH, float displayScaleX, float displayScaleY, bool debugShowCollisionMasks) {
+    if (runner->pendingRoom != -1) return;
+
     Renderer* renderer = runner->renderer;
     Room* activeRoom = runner->currentRoom;
     bool anyViewRendered = false;
@@ -2317,6 +2319,57 @@ static void persistRoomState(Runner* runner, int32_t roomIndex) {
     state->initialized = true;
 }
 
+void Runner_handlePendingRoomChange(Runner* runner) {
+    // Handle game restart
+    if (runner->pendingRoom == ROOM_RESTARTGAME) {
+        // See you soon!
+        // Free the currently-loaded non-eager room before reset so lazyLoadRooms stays steady-state.
+        if (runner->dataWin->lazyLoadRooms && runner->currentRoom != nullptr && !runner->currentRoom->eagerlyLoaded) {
+            DataWin_freeRoomPayload(runner->currentRoom);
+        }
+        Runner_reset(runner);
+        Runner_initFirstRoom(runner);
+        return;
+    }
+
+    // Handle room transition
+    if (runner->pendingRoom >= 0) {
+        int32_t oldRoomIndex = runner->currentRoomIndex;
+        Room* oldRoom = runner->currentRoom;
+        const char* oldRoomName = oldRoom->name;
+
+        // Clear pendingRoom BEFORE firing Room End so the dispatch gate lets the events through.
+        int32_t newRoomIndex = runner->pendingRoom;
+        runner->pendingRoom = -1;
+
+        // Fire Room End for all instances
+        Runner_executeEventForAll(runner, EVENT_OTHER, OTHER_ROOM_END);
+        require(runner->dataWin->room.count > (uint32_t) newRoomIndex);
+        const char* newRoomName = runner->dataWin->room.rooms[newRoomIndex].name;
+
+        fprintf(stderr, "Room changed: %s (room %d) -> %s (room %d)\n", oldRoomName, oldRoomIndex, newRoomName, newRoomIndex);
+
+        // If the old room is persistent, save its instance and visual state
+        if (oldRoom->persistent) {
+            persistRoomState(runner, oldRoomIndex);
+        }
+
+        // Free the outgoing room's payload under lazyLoadRooms, unless it's eagerly pinned or we're restarting the same room (initRoom would just re-load it).
+        if (runner->dataWin->lazyLoadRooms && !oldRoom->eagerlyLoaded && newRoomIndex != oldRoomIndex) {
+            DataWin_freeRoomPayload(oldRoom);
+        }
+
+        // Load new room
+        initRoom(runner, newRoomIndex);
+
+        // Fire Room Start for all instances
+        Runner_executeEventForAll(runner, EVENT_OTHER, OTHER_ROOM_START);
+
+        Runner_cleanupDestroyedInstances(runner);
+        Runner_sweepDeadStructs(runner);
+    }
+}
+
 void Runner_step(Runner* runner) {
     // The snapshot arena is stack-like and every push must be matched with a pop within the same frame. Assert that invariant at the top of each step: a non-zero length here means some site below pushed without popping, and we want a loud failure with the offending length so we can find it instead of silently leaking until the next frame.
     requireMessageFormatted(arrlen(runner->instanceSnapshots) == 0, "instanceSnapshots arena was not fully popped at end of previous frame (length=%td)", arrlen(runner->instanceSnapshots));
@@ -2532,53 +2585,6 @@ void Runner_step(Runner* runner) {
 
     // Update view following
     updateViews(runner);
-
-    // Handle game restart
-    if (runner->pendingRoom == ROOM_RESTARTGAME) {
-        // See you soon!
-        // Free the currently-loaded non-eager room before reset so lazyLoadRooms stays steady-state.
-        if (runner->dataWin->lazyLoadRooms && runner->currentRoom != nullptr && !runner->currentRoom->eagerlyLoaded) {
-            DataWin_freeRoomPayload(runner->currentRoom);
-        }
-        Runner_reset(runner);
-        Runner_initFirstRoom(runner);
-        runner->frameCount++;
-        return;
-    }
-
-    // Handle room transition
-    if (runner->pendingRoom >= 0) {
-        int32_t oldRoomIndex = runner->currentRoomIndex;
-        Room* oldRoom = runner->currentRoom;
-        const char* oldRoomName = oldRoom->name;
-
-        // Clear pendingRoom BEFORE firing Room End so the dispatch gate lets the events through.
-        int32_t newRoomIndex = runner->pendingRoom;
-        runner->pendingRoom = -1;
-
-        // Fire Room End for all instances
-        Runner_executeEventForAll(runner, EVENT_OTHER, OTHER_ROOM_END);
-        require(runner->dataWin->room.count > (uint32_t) newRoomIndex);
-        const char* newRoomName = runner->dataWin->room.rooms[newRoomIndex].name;
-
-        fprintf(stderr, "Room changed: %s (room %d) -> %s (room %d)\n", oldRoomName, oldRoomIndex, newRoomName, newRoomIndex);
-
-        // If the old room is persistent, save its instance and visual state
-        if (oldRoom->persistent) {
-            persistRoomState(runner, oldRoomIndex);
-        }
-
-        // Free the outgoing room's payload under lazyLoadRooms, unless it's eagerly pinned or we're restarting the same room (initRoom would just re-load it).
-        if (runner->dataWin->lazyLoadRooms && !oldRoom->eagerlyLoaded && newRoomIndex != oldRoomIndex) {
-            DataWin_freeRoomPayload(oldRoom);
-        }
-
-        // Load new room
-        initRoom(runner, newRoomIndex);
-
-        // Fire Room Start for all instances
-        Runner_executeEventForAll(runner, EVENT_OTHER, OTHER_ROOM_START);
-    }
 
     Runner_cleanupDestroyedInstances(runner);
     Runner_sweepDeadStructs(runner);

--- a/src/runner.h
+++ b/src/runner.h
@@ -436,6 +436,7 @@ void Runner_reset(Runner* runner);
 Runner* Runner_create(DataWin* dataWin, VMContext* vm, Renderer* renderer, FileSystem* fileSystem, AudioSystem* audioSystem);
 void Runner_initFirstRoom(Runner* runner);
 void Runner_step(Runner* runner);
+void Runner_handlePendingRoomChange(Runner* runner);
 void Runner_executeEvent(Runner* runner, Instance* instance, int32_t eventType, int32_t eventSubtype);
 void Runner_executeEventFromObject(Runner* runner, Instance* instance, int32_t startObjectIndex, int32_t eventType, int32_t eventSubtype);
 void Runner_executeEventForAll(Runner* runner, int32_t eventType, int32_t eventSubtype);

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -151,6 +151,7 @@ void* loop() {
 
         // Just like glfwSwapBuffers
         emscripten_webgl_commit_frame();
+        Runner_handlePendingRoomChange(gRunner);
 
         // Frame pacing: sleep until the next frame is due, based on the room's speed.
         // emscripten_get_now() returns milliseconds (performance.now()) and works in workers.


### PR DESCRIPTION
**Prevents rooms from drawing their initial state before the first step runs.**
This aligns room-switch timing with the decompiled yoyo runner.


<img width="800" height="325" alt="BUGSBUGSBUGS" src="https://github.com/user-attachments/assets/8159ed31-e17c-49e0-a17d-911ada2ecd74" />