### PR TITLE
fix: at ps3gl in ps3gl.c

### DIFF
--- a/vendor/ps3gl/ps3gl.c
+++ b/vendor/ps3gl/ps3gl.c
@@ -830,9 +830,11 @@ void glTexImage2D( GLenum target, GLint level,
 		}
 		case GL_RGBA:
 		{
-			currentTexture->data = (uint8_t*)rsxMemalign(128, width*height*4);
+			if(width <= 0 || height <= 0 || (size_t)width > (SIZE_MAX / 4) / (size_t)height) return;
+			const size_t textureSize = (size_t)width * (size_t)height * 4;
+			currentTexture->data = (uint8_t*)rsxMemalign(128, textureSize);
 			if(pixels)
-				memcpy((void*)currentTexture->data, pixels, width*height*4);
+				memcpy((void*)currentTexture->data, pixels, textureSize);
 			rsxAddressToOffset(currentTexture->data, &currentTexture->gcmTexture.offset);
 			currentTexture->gcmTexture.format = GCM_TEXTURE_FORMAT_A8R8G8B8|GCM_TEXTURE_FORMAT_LIN;
 			currentTexture->gcmTexture.remap  = (
@@ -874,10 +876,11 @@ void glTexSubImage2D(
 		case GL_RGBA8:
 		case 4:
 		{
-			const int textureSize = width*height*4;
+			if(width <= 0 || height <= 0 || (size_t)width > (SIZE_MAX / 4) / (size_t)height) break;
+			const size_t textureSize = (size_t)width * (size_t)height * 4;
 			transferBuffer = (uint8_t*)rsxMemalign(128, textureSize);
 			u32 transferBufferOffset;
-			memcpy((void*)transferBuffer, pixels, width*height*4);
+			memcpy((void*)transferBuffer, pixels, textureSize);
 			rsxAddressToOffset(transferBuffer, &transferBufferOffset);
 			rsxSetTransferImage(
 				context, // context


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `vendor/ps3gl/ps3gl.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `vendor/ps3gl/ps3gl.c:835` |

**Description**: At ps3gl.c lines 835 and 880, memcpy is called with a copy length of width*height*4 computed from caller-supplied texture dimensions. There is no validation that the destination buffer (currentTexture->data or transferBuffer) was allocated with at least width*height*4 bytes, nor any check that the multiplication itself does not overflow. A crafted texture asset with large or specially chosen width/height values can cause the memcpy to write beyond the allocated heap region, corrupting adjacent heap metadata or objects.

## Changes
- `vendor/ps3gl/ps3gl.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
