### PR TITLE
Stub/implement os_is_paused, psn_init_np_libs, and psn_setup_trophies

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -2599,6 +2599,10 @@ static RValue builtinOsGetRegion(MAYBE_UNUSED VMContext* ctx, MAYBE_UNUSED RValu
     return RValue_makeOwnedString(safeStrdup("US"));
 }
 
+static RValue builtinOsIsPaused(MAYBE_UNUSED VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
+    return RValue_makeBool(false);
+}
+
 // ===[ DS_MAP BUILTIN FUNCTIONS ]===
 
 static inline ptrdiff_t getValueIndexInMap(DsMapEntry** mapPtr, RValue keyRvalue) {
@@ -5263,8 +5267,14 @@ static RValue builtin_bufferGetSurface(VMContext* ctx, RValue* args, MAYBE_UNUSE
 
 // PSN stubs
 STUB_RETURN_UNDEFINED(psn_init)
+STUB_RETURN_UNDEFINED(psn_init_np_libs)
 STUB_RETURN_ZERO(psn_default_user)
 STUB_RETURN_ZERO(psn_get_leaderboard_score)
+
+static RValue builtin_PSNSetupTrophies(MAYBE_UNUSED VMContext* ctx, RValue* args, MAYBE_UNUSED int32_t argCount) {
+    // Always tells the runner that trophies have been set up successfully
+    return RValue_makeInt32(1);
+}
 
 // Draw functions
 static RValue builtin_drawSprite(VMContext* ctx, RValue* args, MAYBE_UNUSED int32_t argCount) {
@@ -8989,6 +8999,7 @@ void VMBuiltins_registerAll(VMContext* ctx) {
     // OS
     VM_registerBuiltin(ctx, "os_get_language", builtinOsGetLanguage);
     VM_registerBuiltin(ctx, "os_get_region", builtinOsGetRegion);
+    VM_registerBuiltin(ctx, "os_is_paused", builtinOsIsPaused);
 
     // ds_map
     VM_registerBuiltin(ctx, "ds_map_create", builtinDsMapCreate);
@@ -9194,8 +9205,10 @@ void VMBuiltins_registerAll(VMContext* ctx) {
 
     // PSN
     VM_registerBuiltin(ctx, "psn_init", builtin_psn_init);
+    VM_registerBuiltin(ctx, "psn_init_np_libs", builtin_psn_init_np_libs);
     VM_registerBuiltin(ctx, "psn_default_user", builtin_psn_default_user);
     VM_registerBuiltin(ctx, "psn_get_leaderboard_score", builtin_psn_get_leaderboard_score);
+    VM_registerBuiltin(ctx, "psn_setup_trophies", builtin_PSNSetupTrophies);
 
     // Draw
     VM_registerBuiltin(ctx, "draw_sprite", builtin_drawSprite);


### PR DESCRIPTION
Addresses multiple missing functions when running the PS Vita version of UNDERTALE with `os_type = psvita`.

`os_is_paused` is used to check if the game has been interrupted by the operating system on various devices. For simplicity, this is always set to return false (unpaused).

`psn_init_np_libs` is stubbed.

`psn_setup_trophies` is used to check if the game has finished setting up Trophies (PlayStation achievements). Previously when running UNDERTALE with `os_type = psvita`, the game would get stuck on a screen waiting for the trophies to get set up. Forcing `psn_setup_trophies` to always return 1 allows us to get past this screen.