### PR TITLE
make the runner actually care about the playback speed type for sprites

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -2452,10 +2452,13 @@ void Runner_step(Runner* runner) {
         if (!inst->active) continue;
         if (0 > inst->spriteIndex) continue;
 
-        inst->imageIndex += inst->imageSpeed;
-
         // Wrap image_index (matches HTML5 runner: manual subtract/add instead of using fmod)
         Sprite* sprite = &runner->dataWin->sprt.sprites[inst->spriteIndex];
+        if (sprite->gms2PlaybackSpeedType == true) {
+            inst->imageIndex += inst->imageSpeed;
+        } else {
+            inst->imageIndex += (1.0/runner->currentRoom->speed) * sprite->gms2PlaybackSpeed * inst->imageSpeed;
+        }   
         float frameCount = (float) sprite->textureCount;
         bool wrapped = false;
         if (inst->imageIndex >= frameCount) {


### PR DESCRIPTION
I believe this is the right way, I hope, oh well makes the sprites not animate at the speed of sound in DELTARUNE's cooking minigame