### PR TITLE
Window, Surface and Stuffs

### DIFF
--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -345,10 +345,21 @@ static void glBeginGUI(Renderer* renderer, int32_t guiW, int32_t guiH, int32_t p
     gl->quadCount = 0;
     gl->currentTextureId = 0;
 
-    int32_t glPortY = gl->gameH - portY - portH;
-    glViewport(portX, glPortY, portW, portH);
+    GLint boundFbo = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &boundFbo);
+
+    int32_t glPortY;
+    if (boundFbo == 0) {
+        glPortY = 0;
+        glViewport(0, 0, guiW, guiH);
+        glScissor(0, 0, guiW, guiH);
+    } else {
+        glPortY = gl->gameH - portY - portH;
+        glViewport(portX, glPortY, portW, portH);
+        glScissor(portX, glPortY, portW, portH);
+    }
+
     glEnable(GL_SCISSOR_TEST);
-    glScissor(portX, glPortY, portW, portH);
 
     Matrix4f projection;
     Matrix4f_identity(&projection);

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -379,7 +379,7 @@ static void glEndGUI(Renderer* renderer) {
     glDisable(GL_SCISSOR_TEST);
 }
 
-static void glEndFrame(Renderer* renderer) {
+static void glEndFrameInit(Renderer* renderer) {
     GLRenderer* gl = (GLRenderer*) renderer;
     glBindVertexArray(0);
 
@@ -387,7 +387,16 @@ static void glEndFrame(Renderer* renderer) {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         return;
     }
-    GLCommon_letterboxBlit(gl->fbo, gl->fboWidth, gl->fboHeight, gl->gameW, gl->gameH, gl->windowW, gl->windowH);
+    GLCommon_beginLetterboxBlit(gl->fbo);
+}
+
+static void glEndFrameEnd(Renderer* renderer) {
+    GLRenderer* gl = (GLRenderer*) renderer;
+
+    if (renderer->usingAppSurface && !renderer->appSurfaceAutoDraw) {
+        return;
+    }
+    GLCommon_endLetterboxBlit(gl->fboWidth, gl->fboHeight, gl->gameW, gl->gameH, gl->windowW, gl->windowH);
 }
 
 static void glRendererFlush(Renderer* renderer) {
@@ -1713,7 +1722,8 @@ static RendererVtable glVtable = {
     .init = glInit,
     .destroy = glDestroy,
     .beginFrame = glBeginFrame,
-    .endFrame = glEndFrame,
+    .endFrameInit = glEndFrameInit,
+    .endFrameEnd = glEndFrameEnd,
     .beginView = glBeginView,
     .endView = glEndView,
     .beginGUI = glBeginGUI,

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -382,6 +382,11 @@ static void glEndGUI(Renderer* renderer) {
 static void glEndFrame(Renderer* renderer) {
     GLRenderer* gl = (GLRenderer*) renderer;
     glBindVertexArray(0);
+
+    if (renderer->usingAppSurface && !renderer->appSurfaceAutoDraw) {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        return;
+    }
     GLCommon_letterboxBlit(gl->fbo, gl->fboWidth, gl->fboHeight, gl->gameW, gl->gameH, gl->windowW, gl->windowH);
 }
 
@@ -1761,5 +1766,7 @@ Renderer* GLRenderer_create(void) {
     gl->base.drawHalign = 0;
     gl->base.drawValign = 0;
     gl->base.circlePrecision = 24;
+    gl->base.appSurfaceAutoDraw = true;
+    gl->base.usingAppSurface = true;
     return (Renderer*) gl;
 }

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -351,8 +351,8 @@ static void glBeginGUI(Renderer* renderer, int32_t guiW, int32_t guiH, int32_t p
     int32_t glPortY;
     if (boundFbo == 0) {
         glPortY = 0;
-        glViewport(0, 0, guiW, guiH);
-        glScissor(0, 0, guiW, guiH);
+        glViewport(0, 0, portW, portH);
+        glScissor(0, 0, portW, portH);
     } else {
         glPortY = gl->gameH - portY - portH;
         glViewport(portX, glPortY, portW, portH);

--- a/src/gl_common/gl_common.c
+++ b/src/gl_common/gl_common.c
@@ -50,11 +50,14 @@ void GLCommon_computeLetterbox(int32_t gameW, int32_t gameH, int32_t windowW, in
     *outEndY = startY + effH;
 }
 
-void GLCommon_letterboxBlit(GLuint fbo, int32_t fboWidth, int32_t fboHeight, int32_t gameW, int32_t gameH, int32_t windowW, int32_t windowH) {
-    int32_t sx, sy, ex, ey;
-    GLCommon_computeLetterbox(gameW, gameH, windowW, windowH, &sx, &sy, &ex, &ey);
+void GLCommon_beginLetterboxBlit(GLuint fbo) {
     glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+}
+
+void GLCommon_endLetterboxBlit(int32_t fboWidth, int32_t fboHeight, int32_t gameW, int32_t gameH, int32_t windowW, int32_t windowH) {
+    int32_t sx, sy, ex, ey;
+    GLCommon_computeLetterbox(gameW, gameH, windowW, windowH, &sx, &sy, &ex, &ey);
     glBlitFramebuffer(0, 0, fboWidth, fboHeight, sx, sy, ex, ey, GL_COLOR_BUFFER_BIT, GL_NEAREST);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }

--- a/src/gl_common/gl_common.h
+++ b/src/gl_common/gl_common.h
@@ -25,7 +25,8 @@ void GLCommon_resizeMainFBO(GLuint* fboTexture, GLuint fbo, int32_t* fboWidth, i
 void GLCommon_computeLetterbox(int32_t gameW, int32_t gameH, int32_t windowW, int32_t windowH, int32_t* outStartX, int32_t* outStartY, int32_t* outEndX, int32_t* outEndY);
 
 // Blits the main FBO to the default framebuffer with letterboxing.
-void GLCommon_letterboxBlit(GLuint fbo, int32_t fboWidth, int32_t fboHeight, int32_t gameW, int32_t gameH, int32_t windowW, int32_t windowH);
+void GLCommon_beginLetterboxBlit(GLuint fbo);
+void GLCommon_endLetterboxBlit(int32_t fboWidth, int32_t fboHeight, int32_t gameW, int32_t gameH, int32_t windowW, int32_t windowH);
 
 // ===[ Surface arrays ]===
 

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -279,10 +279,24 @@ static void glEndGUI(MAYBE_UNUSED Renderer* renderer) {
     glDisable(GL_SCISSOR_TEST);
 }
 
-static void glEndFrame(Renderer* renderer) {
+static void glEndFrameInit(Renderer* renderer) {
     MAYBE_UNUSED GLLegacyRenderer* gl = (GLLegacyRenderer*) renderer;
 #ifndef PLATFORM_PS3
-    GLCommon_letterboxBlit(gl->fbo, gl->fboWidth, gl->fboHeight, gl->gameW, gl->gameH, gl->windowW, gl->windowH);
+    if (renderer->usingAppSurface && !renderer->appSurfaceAutoDraw) {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        return;
+    }
+    GLCommon_beginLetterboxBlit(gl->fbo);
+#endif
+}
+
+static void glEndFrameEnd(Renderer* renderer) {
+    MAYBE_UNUSED GLLegacyRenderer* gl = (GLLegacyRenderer*) renderer;
+#ifndef PLATFORM_PS3
+    if (renderer->usingAppSurface && !renderer->appSurfaceAutoDraw) {
+        return;
+    }
+    GLCommon_endLetterboxBlit(gl->fboWidth, gl->fboHeight, gl->gameW, gl->gameH, gl->windowW, gl->windowH);
 #endif
 }
 
@@ -1606,7 +1620,8 @@ static RendererVtable glVtable = {
     .init = glInit,
     .destroy = glDestroy,
     .beginFrame = glBeginFrame,
-    .endFrame = glEndFrame,
+    .endFrameInit = glEndFrameInit,
+    .endFrameEnd = glEndFrameEnd,
     .beginView = glBeginView,
     .endView = glEndView,
     .beginGUI = glBeginGUI,

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -250,6 +250,9 @@ static void glBeginGUI(Renderer* renderer, int32_t guiW, int32_t guiH, int32_t p
 
     glBindTexture(GL_TEXTURE_2D, 0);
 
+#ifdef PLATFORM_PS3
+    glApplyViewport(gl, portX, portY, portW, portH);
+#else
     GLint boundFbo = 0;
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &boundFbo);
     if (boundFbo == 0) {
@@ -259,6 +262,7 @@ static void glBeginGUI(Renderer* renderer, int32_t guiW, int32_t guiH, int32_t p
     } else {
         glApplyViewport(gl, portX, portY, portW, portH);
     }
+#endif
 
     Matrix4f projection;
     Matrix4f_identity(&projection);

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -256,9 +256,9 @@ static void glBeginGUI(Renderer* renderer, int32_t guiW, int32_t guiH, int32_t p
     GLint boundFbo = 0;
     glGetIntegerv(GL_FRAMEBUFFER_BINDING, &boundFbo);
     if (boundFbo == 0) {
-        glViewport(0, 0, guiW, guiH);
+        glViewport(0, 0, portW, portH);
         glEnable(GL_SCISSOR_TEST);
-        glScissor(0, 0, guiW, guiH);
+        glScissor(0, 0, portW, portH);
     } else {
         glApplyViewport(gl, portX, portY, portW, portH);
     }

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -1658,5 +1658,8 @@ Renderer* GLLegacyRenderer_create(void) {
     gl->colorWriteG = true;
     gl->colorWriteB = true;
     gl->colorWriteA = true;
+
+    gl->base.appSurfaceAutoDraw = true;
+    gl->base.usingAppSurface = true;
     return (Renderer*) gl;
 }

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -250,7 +250,15 @@ static void glBeginGUI(Renderer* renderer, int32_t guiW, int32_t guiH, int32_t p
 
     glBindTexture(GL_TEXTURE_2D, 0);
 
-    glApplyViewport(gl, portX, portY, portW, portH);
+    GLint boundFbo = 0;
+    glGetIntegerv(GL_FRAMEBUFFER_BINDING, &boundFbo);
+    if (boundFbo == 0) {
+        glViewport(0, 0, guiW, guiH);
+        glEnable(GL_SCISSOR_TEST);
+        glScissor(0, 0, guiW, guiH);
+    } else {
+        glApplyViewport(gl, portX, portY, portW, portH);
+    }
 
     Matrix4f projection;
     Matrix4f_identity(&projection);

--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -1394,6 +1394,7 @@ int main(int argc, char* argv[]) {
         float displayScaleX;
         float displayScaleY;
 
+        Runner_drawPre(runner, fbWidth, fbHeight);
         Runner_computeViewDisplayScale(runner, gameW, gameH, &displayScaleX, &displayScaleY);
 
         renderer->vtable->beginFrame(renderer, gameW, gameH, fbWidth, fbHeight);

--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -1368,8 +1368,22 @@ int main(int argc, char* argv[]) {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
         glClear(GL_COLOR_BUFFER_BIT);
 
-        int32_t gameW = (int32_t) gen8->defaultWindowWidth;
-        int32_t gameH = (int32_t) gen8->defaultWindowHeight;
+        if (!runner->appSurfaceEnabled) {
+            runner->applicationWidth = fbWidth;
+            runner->applicationHeight = fbHeight;
+            runner->usingAppSurface = false;
+        } else {
+            if (runner->applicationWidth <= 0 || runner->applicationHeight <= 0) {
+                runner->applicationWidth = (int32_t) gen8->defaultWindowWidth;
+                runner->applicationHeight = (int32_t) gen8->defaultWindowHeight;
+            }
+            runner->usingAppSurface = true;
+        }
+
+        int32_t gameW = runner->applicationWidth;
+        int32_t gameH = runner->applicationHeight;
+        renderer->appSurfaceAutoDraw = runner->appSurfaceAutoDraw;
+        renderer->usingAppSurface = runner->usingAppSurface;
 
         // The application surface (FBO) is sized to defaultWindowWidth x defaultWindowHeight.
         // It is a bit hard to understand, but here's how it works:

--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -1411,8 +1411,9 @@ int main(int argc, char* argv[]) {
 
         Runner_drawViews(runner, gameW, gameH, displayScaleX, displayScaleY, debugShowCollisionMasks);
         renderer->vtable->endFrameInit(renderer);
-        Runner_drawPost(runner, fbWidth, fbHeight, gameW, gameH);
+        Runner_drawPost(runner, fbWidth, fbHeight);
         renderer->vtable->endFrameEnd(renderer);
+        Runner_drawGUI(runner, fbWidth, fbHeight, gameW, gameH);
 
         // Capture screenshot if this frame matches a requested frame
         bool shouldScreenshot = hmget(args.screenshotFrames, runner->frameCount);

--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -741,15 +741,13 @@ static void setGlfwWindowTitle(void* window, const char* title) {
 
 static bool getGlfwWindowSize(void* window, int32_t* outW, int32_t* outH) {
     if (outW == nullptr || outH == nullptr) return false;
-#ifdef USE_GLFW2
-    (void)window;
     int w = 0;
     int h = 0;
+#ifdef USE_GLFW2
+    (void)window;
     glfwGetWindowSize(&w, &h);
 #else
     if (window == nullptr) return false;
-    int w = 0;
-    int h = 0;
     glfwGetWindowSize((GLFWwindow*) window, &w, &h);
 #endif
     if (w <= 0 || h <= 0) return false;

--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -739,6 +739,36 @@ static void setGlfwWindowTitle(void* window, const char* title) {
 #endif
 }
 
+static bool getGlfwWindowSize(void* window, int32_t* outW, int32_t* outH) {
+    if (outW == nullptr || outH == nullptr) return false;
+#ifdef USE_GLFW2
+    (void)window;
+    int w = 0;
+    int h = 0;
+    glfwGetWindowSize(&w, &h);
+#else
+    if (window == nullptr) return false;
+    int w = 0;
+    int h = 0;
+    glfwGetWindowSize((GLFWwindow*) window, &w, &h);
+#endif
+    if (w <= 0 || h <= 0) return false;
+    *outW = w;
+    *outH = h;
+    return true;
+}
+
+static void setGlfwWindowSize(void* window, int32_t width, int32_t height) {
+    if (width <= 0 || height <= 0) return;
+#ifdef USE_GLFW2
+    (void) window;
+    glfwSetWindowSize(width, height);
+#else
+    if (window == nullptr) return;
+    glfwSetWindowSize((GLFWwindow*) window, width, height);
+#endif
+}
+
 static bool getGlfwWindowFocus(void *window) {
 #ifdef USE_GLFW2
     (void)window;
@@ -1105,6 +1135,8 @@ int main(int argc, char* argv[]) {
     runner->debugMode = args.debug;
     runner->osType = args.osType;
     runner->setWindowTitle = setGlfwWindowTitle;
+    runner->getWindowSize = getGlfwWindowSize;
+    runner->setWindowSize = setGlfwWindowSize;
     runner->windowHasFocus = getGlfwWindowFocus;
 #ifdef USE_GLFW2
     runner->nativeWindow = (void*)0xDEADBEEF;

--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -1410,8 +1410,9 @@ int main(int argc, char* argv[]) {
         glClear(GL_COLOR_BUFFER_BIT);
 
         Runner_drawViews(runner, gameW, gameH, displayScaleX, displayScaleY, debugShowCollisionMasks);
-        renderer->vtable->endFrame(renderer);
+        renderer->vtable->endFrameInit(renderer);
         Runner_drawPost(runner, fbWidth, fbHeight, gameW, gameH);
+        renderer->vtable->endFrameEnd(renderer);
 
         // Capture screenshot if this frame matches a requested frame
         bool shouldScreenshot = hmget(args.screenshotFrames, runner->frameCount);

--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -1364,8 +1364,8 @@ int main(int argc, char* argv[]) {
         glClear(GL_COLOR_BUFFER_BIT);
 
         Runner_drawViews(runner, gameW, gameH, displayScaleX, displayScaleY, debugShowCollisionMasks);
-
         renderer->vtable->endFrame(renderer);
+        Runner_drawPost(runner, fbWidth, fbHeight, gameW, gameH);
 
         // Capture screenshot if this frame matches a requested frame
         bool shouldScreenshot = hmget(args.screenshotFrames, runner->frameCount);

--- a/src/ps2/gs_renderer.c
+++ b/src/ps2/gs_renderer.c
@@ -1105,8 +1105,12 @@ static void gsBeginFrame(Renderer* renderer, MAYBE_UNUSED int32_t gameW, MAYBE_U
     }
 }
 
-static void gsEndFrame(MAYBE_UNUSED Renderer* renderer) {
-    // No-op: flip happens in main loop
+static void gsEndFrameInit(MAYBE_UNUSED Renderer* renderer) {
+    // No-op: GS draws directly to the display buffer.
+}
+
+static void gsEndFrameEnd(MAYBE_UNUSED Renderer* renderer) {
+    // No-op: flip happens in main loop.
 }
 
 static void gsBeginView(Renderer* renderer, int32_t viewX, int32_t viewY, int32_t viewW, int32_t viewH, MAYBE_UNUSED int32_t portX, MAYBE_UNUSED int32_t portY, MAYBE_UNUSED int32_t portW, MAYBE_UNUSED int32_t portH, MAYBE_UNUSED float viewAngle) {
@@ -2865,7 +2869,8 @@ static RendererVtable gsVtable = {
     .init = gsInit,
     .destroy = gsDestroy,
     .beginFrame = gsBeginFrame,
-    .endFrame = gsEndFrame,
+    .endFrameInit = gsEndFrameInit,
+    .endFrameEnd = gsEndFrameEnd,
     .beginView = gsBeginView,
     .endView = gsEndView,
     .beginGUI = gsBeginGUI,

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -650,6 +650,7 @@ int main(int argc, char* argv[]) {
         // Render views
         u64 drawStartTime = GetTimerSystemTime();
         Runner_drawViews(runner, gameW, gameH, 1.0f, 1.0f, false);
+        Runner_drawPost(runner);
         u64 drawEndTime = GetTimerSystemTime();
 
         runner->viewCurrent = 0;

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -650,12 +650,10 @@ int main(int argc, char* argv[]) {
         // Render views
         u64 drawStartTime = GetTimerSystemTime();
         Runner_drawViews(runner, gameW, gameH, 1.0f, 1.0f, false);
-        Runner_drawPost(runner);
-        u64 drawEndTime = GetTimerSystemTime();
-
         runner->viewCurrent = 0;
-
         renderer->vtable->endFrame(renderer);
+        Runner_drawPost(runner, 640, 448, gameW, gameH);
+        u64 drawEndTime = GetTimerSystemTime();
 
         // Clear pressed/released edges after both Step and Draw have consumed input
         // This MUST be after Runner_draw because games CAN handle input in Draw events (e.g. Undertale's naming screen)

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -636,6 +636,7 @@ int main(int argc, char* argv[]) {
 
         gsKit_clear(gsGlobal, GS_SETREG_RGBAQ(0x00, 0x00, 0x00, 0x80, 0x00));
 
+        Runner_drawPre(runner, 640, 448);
         renderer->vtable->beginFrame(renderer, gameW, gameH, 640, 448);
 
         // Clear with room background color

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -651,8 +651,9 @@ int main(int argc, char* argv[]) {
         u64 drawStartTime = GetTimerSystemTime();
         Runner_drawViews(runner, gameW, gameH, 1.0f, 1.0f, false);
         runner->viewCurrent = 0;
-        renderer->vtable->endFrame(renderer);
+        renderer->vtable->endFrameInit(renderer);
         Runner_drawPost(runner, 640, 448, gameW, gameH);
+        renderer->vtable->endFrameEnd(renderer);
         u64 drawEndTime = GetTimerSystemTime();
 
         // Clear pressed/released edges after both Step and Draw have consumed input

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -652,8 +652,9 @@ int main(int argc, char* argv[]) {
         Runner_drawViews(runner, gameW, gameH, 1.0f, 1.0f, false);
         runner->viewCurrent = 0;
         renderer->vtable->endFrameInit(renderer);
-        Runner_drawPost(runner, 640, 448, gameW, gameH);
+        Runner_drawPost(runner, 640, 448);
         renderer->vtable->endFrameEnd(renderer);
+        Runner_drawGUI(runner, 640, 448, gameW, gameH);
         u64 drawEndTime = GetTimerSystemTime();
 
         // Clear pressed/released edges after both Step and Draw have consumed input

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -418,6 +418,7 @@ int main(int argc, char* argv[]) {
 
         double drawStart = PS3_GET_TIME;
         Runner_drawViews(runner, gameW, gameH, displayScaleX, displayScaleY, debugShowCollisionMasks);
+        Runner_drawPost(runner);
 
         renderer->vtable->endFrame(renderer);
         double drawTime = PS3_GET_TIME - drawStart;

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -418,9 +418,8 @@ int main(int argc, char* argv[]) {
 
         double drawStart = PS3_GET_TIME;
         Runner_drawViews(runner, gameW, gameH, displayScaleX, displayScaleY, debugShowCollisionMasks);
-        Runner_drawPost(runner);
-
         renderer->vtable->endFrame(renderer);
+        Runner_drawPost(runner, fbWidth, fbHeight, gameW, gameH);
         double drawTime = PS3_GET_TIME - drawStart;
 
         // ===[ Debug Overlay ]===

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -418,8 +418,9 @@ int main(int argc, char* argv[]) {
 
         double drawStart = PS3_GET_TIME;
         Runner_drawViews(runner, gameW, gameH, displayScaleX, displayScaleY, debugShowCollisionMasks);
-        renderer->vtable->endFrame(renderer);
+        renderer->vtable->endFrameInit(renderer);
         Runner_drawPost(runner, fbWidth, fbHeight, gameW, gameH);
+        renderer->vtable->endFrameEnd(renderer);
         double drawTime = PS3_GET_TIME - drawStart;
 
         // ===[ Debug Overlay ]===

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -419,8 +419,9 @@ int main(int argc, char* argv[]) {
         double drawStart = PS3_GET_TIME;
         Runner_drawViews(runner, gameW, gameH, displayScaleX, displayScaleY, debugShowCollisionMasks);
         renderer->vtable->endFrameInit(renderer);
-        Runner_drawPost(runner, fbWidth, fbHeight, gameW, gameH);
+        Runner_drawPost(runner, fbWidth, fbHeight);
         renderer->vtable->endFrameEnd(renderer);
+        Runner_drawGUI(runner, fbWidth, fbHeight, gameW, gameH);
         double drawTime = PS3_GET_TIME - drawStart;
 
         // ===[ Debug Overlay ]===

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -401,6 +401,7 @@ int main(int argc, char* argv[]) {
         float displayScaleX;
         float displayScaleY;
 
+        Runner_drawPre(runner, fbWidth, fbHeight);
         Runner_computeViewDisplayScale(runner, gameW, gameH, &displayScaleX, &displayScaleY);
 
         renderer->vtable->beginFrame(renderer, gameW, gameH, fbWidth, fbHeight);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -48,7 +48,8 @@ typedef struct {
     void (*init)(Renderer* renderer, DataWin* dataWin);
     void (*destroy)(Renderer* renderer);
     void (*beginFrame)(Renderer* renderer, int32_t gameW, int32_t gameH, int32_t windowW, int32_t windowH);
-    void (*endFrame)(Renderer* renderer);
+    void (*endFrameInit)(Renderer* renderer);
+    void (*endFrameEnd)(Renderer* renderer);
     void (*beginView)(Renderer* renderer, int32_t viewX, int32_t viewY, int32_t viewW, int32_t viewH, int32_t portX, int32_t portY, int32_t portW, int32_t portH, float viewAngle);
     void (*endView)(Renderer* renderer);
     // GUI pass: coordinates are (0,0)..(guiW,guiH) mapped to the current view's port rect. Called after endView.

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -116,6 +116,8 @@ struct Renderer {
     int32_t CPortY;
     int32_t CPortW;
     int32_t CPortH;
+    bool appSurfaceAutoDraw;
+    bool usingAppSurface;
 };
 
 // ===[ Shared Helpers (platform-agnostic) ]===

--- a/src/runner.c
+++ b/src/runner.c
@@ -852,8 +852,6 @@ void Runner_draw(Runner* runner) {
 
     // Draw foreground backgrounds (in front of instances, behind GUI)
     Runner_drawBackgrounds(runner, true);
-
-    fireDrawSubtype(runner, drawables, drawableCount, DRAW_POST);
 }
 
 void Runner_drawGUI(Runner* runner) {
@@ -864,6 +862,16 @@ void Runner_drawGUI(Runner* runner) {
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI_BEGIN);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI_END);
+}
+
+void Runner_drawPost(Runner* runner, int32_t windowW, int32_t windowH, int32_t targetW, int32_t targetH) {
+    rebuildDrawableCacheIfDirty(runner);
+    Drawable* drawables = runner->cachedDrawables;
+    int32_t drawableCount = (int32_t) arrlen(drawables);
+
+    runner->renderer->vtable->beginGUI(runner->renderer, windowW, windowH, 0, 0, targetW, targetH);
+    fireDrawSubtype(runner, drawables, drawableCount, DRAW_POST);
+    runner->renderer->vtable->endGUI(runner->renderer);
 }
 
 void Runner_computeViewDisplayScale(Runner* runner, int32_t gameW, int32_t gameH, float* outScaleX, float* outScaleY) {

--- a/src/runner.c
+++ b/src/runner.c
@@ -1591,7 +1591,8 @@ static void validateRendererVtable(Renderer* renderer) {
     requireNotNullFunction(init);
     requireNotNullFunction(destroy);
     requireNotNullFunction(beginFrame);
-    requireNotNullFunction(endFrame);
+    requireNotNullFunction(endFrameInit);
+    requireNotNullFunction(endFrameEnd);
     requireNotNullFunction(beginView);
     requireNotNullFunction(endView);
     requireNotNullFunction(beginGUI);

--- a/src/runner.c
+++ b/src/runner.c
@@ -1649,6 +1649,13 @@ Runner* Runner_create(DataWin* dataWin, VMContext* vm, Renderer* renderer, FileS
     runner->osType = OS_WINDOWS;
     runner->keyboard = RunnerKeyboard_create();
     runner->gamepads = RunnerGamepad_create();
+    runner->appSurfaceEnabled = true;
+    runner->appSurfaceAutoDraw = true;
+    runner->usingAppSurface = true;
+    runner->applicationWidth = (int32_t) dataWin->gen8.defaultWindowWidth;
+    runner->applicationHeight = (int32_t) dataWin->gen8.defaultWindowHeight;
+    runner->oldApplicationWidth = runner->applicationWidth;
+    runner->oldApplicationHeight = runner->applicationHeight;
 
     repeat(MAX_SURFACES, i) {
         runner->surfaceStack[i] = -1;

--- a/src/runner.c
+++ b/src/runner.c
@@ -646,8 +646,6 @@ void Runner_draw(Runner* runner) {
     if (!DataWin_isVersionAtLeast(runner->dataWin, 2, 0, 0, 0))
         Runner_drawBackgrounds(runner, false);
 
-    // Fire draw subtypes in correct GameMaker order. fireDrawSubtype walks the cache and filters inline.
-    fireDrawSubtype(runner, drawables, drawableCount, DRAW_PRE);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_BEGIN);
 
     // Draw interleaved tiles and instances
@@ -865,6 +863,16 @@ void Runner_drawGUI(Runner* runner, int32_t windowW, int32_t windowH, int32_t ta
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI_BEGIN);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI_END);
+    runner->renderer->vtable->endGUI(runner->renderer);
+}
+
+void Runner_drawPre(Runner* runner, int32_t windowW, int32_t windowH) {
+    rebuildDrawableCacheIfDirty(runner);
+    Drawable* drawables = runner->cachedDrawables;
+    int32_t drawableCount = (int32_t) arrlen(drawables);
+
+    runner->renderer->vtable->beginGUI(runner->renderer, windowW, windowH, 0, 0, windowW, windowH);
+    fireDrawSubtype(runner, drawables, drawableCount, DRAW_PRE);
     runner->renderer->vtable->endGUI(runner->renderer);
 }
 

--- a/src/runner.c
+++ b/src/runner.c
@@ -854,22 +854,26 @@ void Runner_draw(Runner* runner) {
     Runner_drawBackgrounds(runner, true);
 }
 
-void Runner_drawGUI(Runner* runner) {
+void Runner_drawGUI(Runner* runner, int32_t windowW, int32_t windowH, int32_t targetW, int32_t targetH) {
     rebuildDrawableCacheIfDirty(runner);
     Drawable* drawables = runner->cachedDrawables;
     int32_t drawableCount = (int32_t) arrlen(drawables);
 
+    int32_t guiW = runner->guiWidth > 0 ? runner->guiWidth : targetW;
+    int32_t guiH = runner->guiHeight > 0 ? runner->guiHeight : targetH;
+    runner->renderer->vtable->beginGUI(runner->renderer, guiW, guiH, 0, 0, windowW, windowH);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI_BEGIN);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_GUI_END);
+    runner->renderer->vtable->endGUI(runner->renderer);
 }
 
-void Runner_drawPost(Runner* runner, int32_t windowW, int32_t windowH, int32_t targetW, int32_t targetH) {
+void Runner_drawPost(Runner* runner, int32_t windowW, int32_t windowH) {
     rebuildDrawableCacheIfDirty(runner);
     Drawable* drawables = runner->cachedDrawables;
     int32_t drawableCount = (int32_t) arrlen(drawables);
 
-    runner->renderer->vtable->beginGUI(runner->renderer, windowW, windowH, 0, 0, targetW, targetH);
+    runner->renderer->vtable->beginGUI(runner->renderer, windowW, windowH, 0, 0, windowW, windowH);
     fireDrawSubtype(runner, drawables, drawableCount, DRAW_POST);
     runner->renderer->vtable->endGUI(runner->renderer);
 }
@@ -931,12 +935,6 @@ void Runner_drawViews(Runner* runner, int32_t gameW, int32_t gameH, float displa
 
             renderer->vtable->endView(renderer);
 
-            int32_t guiW = runner->guiWidth > 0 ? runner->guiWidth : portW;
-            int32_t guiH = runner->guiHeight > 0 ? runner->guiHeight : portH;
-            renderer->vtable->beginGUI(renderer, guiW, guiH, portX, portY, portW, portH);
-            Runner_drawGUI(runner);
-            renderer->vtable->endGUI(renderer);
-
             anyViewRendered = true;
         }
     }
@@ -951,11 +949,6 @@ void Runner_drawViews(Runner* runner, int32_t gameW, int32_t gameH, float displa
 
         renderer->vtable->endView(renderer);
 
-        int32_t guiW = runner->guiWidth > 0 ? runner->guiWidth : gameW;
-        int32_t guiH = runner->guiHeight > 0 ? runner->guiHeight : gameH;
-        renderer->vtable->beginGUI(renderer, guiW, guiH, 0, 0, gameW, gameH);
-        Runner_drawGUI(runner);
-        renderer->vtable->endGUI(renderer);
     }
 
     // Reset view_current to 0 so non-Draw events (Step, Alarm, Create) see view_current = 0

--- a/src/runner.h
+++ b/src/runner.h
@@ -361,6 +361,14 @@ struct Runner {
     bool drawBackgroundColor;
     bool shouldExit;
     bool debugMode;
+    // application_surface runtime state (mirrors GML toggles)
+    bool appSurfaceEnabled;
+    bool appSurfaceAutoDraw;
+    bool usingAppSurface;
+    int32_t applicationWidth;
+    int32_t applicationHeight;
+    int32_t oldApplicationWidth;
+    int32_t oldApplicationHeight;
     void* nativeWindow;
     void (*setWindowTitle)(void* window, const char* title);
     bool (*getWindowSize)(void* window, int32_t* outW, int32_t* outH);

--- a/src/runner.h
+++ b/src/runner.h
@@ -447,6 +447,7 @@ void Runner_executeEventFromObject(Runner* runner, Instance* instance, int32_t s
 void Runner_executeEventForAll(Runner* runner, int32_t eventType, int32_t eventSubtype);
 void Runner_draw(Runner* runner);
 void Runner_drawGUI(Runner* runner);
+void Runner_drawPost(Runner* runner, int32_t windowW, int32_t windowH, int32_t targetW, int32_t targetH);
 void Runner_drawBackgrounds(Runner* runner, bool foreground);
 void Runner_computeViewDisplayScale(Runner* runner, int32_t gameW, int32_t gameH, float* outScaleX, float* outScaleY);
 void Runner_drawViews(Runner* runner, int32_t gameW, int32_t gameH, float displayScaleX, float displayScaleY, bool debugShowCollisionMasks);

--- a/src/runner.h
+++ b/src/runner.h
@@ -456,8 +456,8 @@ void Runner_executeEvent(Runner* runner, Instance* instance, int32_t eventType, 
 void Runner_executeEventFromObject(Runner* runner, Instance* instance, int32_t startObjectIndex, int32_t eventType, int32_t eventSubtype);
 void Runner_executeEventForAll(Runner* runner, int32_t eventType, int32_t eventSubtype);
 void Runner_draw(Runner* runner);
-void Runner_drawGUI(Runner* runner);
-void Runner_drawPost(Runner* runner, int32_t windowW, int32_t windowH, int32_t targetW, int32_t targetH);
+void Runner_drawGUI(Runner* runner, int32_t windowW, int32_t windowH, int32_t targetW, int32_t targetH);
+void Runner_drawPost(Runner* runner, int32_t windowW, int32_t windowH);
 void Runner_drawBackgrounds(Runner* runner, bool foreground);
 void Runner_computeViewDisplayScale(Runner* runner, int32_t gameW, int32_t gameH, float* outScaleX, float* outScaleY);
 void Runner_drawViews(Runner* runner, int32_t gameW, int32_t gameH, float displayScaleX, float displayScaleY, bool debugShowCollisionMasks);

--- a/src/runner.h
+++ b/src/runner.h
@@ -457,6 +457,7 @@ void Runner_executeEventFromObject(Runner* runner, Instance* instance, int32_t s
 void Runner_executeEventForAll(Runner* runner, int32_t eventType, int32_t eventSubtype);
 void Runner_draw(Runner* runner);
 void Runner_drawGUI(Runner* runner, int32_t windowW, int32_t windowH, int32_t targetW, int32_t targetH);
+void Runner_drawPre(Runner* runner, int32_t windowW, int32_t windowH);
 void Runner_drawPost(Runner* runner, int32_t windowW, int32_t windowH);
 void Runner_drawBackgrounds(Runner* runner, bool foreground);
 void Runner_computeViewDisplayScale(Runner* runner, int32_t gameW, int32_t gameH, float* outScaleX, float* outScaleY);

--- a/src/runner.h
+++ b/src/runner.h
@@ -363,6 +363,8 @@ struct Runner {
     bool debugMode;
     void* nativeWindow;
     void (*setWindowTitle)(void* window, const char* title);
+    bool (*getWindowSize)(void* window, int32_t* outW, int32_t* outH);
+    void (*setWindowSize)(void* window, int32_t width, int32_t height);
     bool (*windowHasFocus)(void* window);
     TileLayerMapEntry* tileLayerMap; // stb_ds hashmap: depth -> tile layer state
     RuntimeLayer* runtimeLayers; // stb_ds array, index-parallel to currentRoom->layers for parsed entries; dynamic entries appended

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -4542,15 +4542,48 @@ static RValue builtinJoystickAxes(VMContext* ctx, RValue* args, MAYBE_UNUSED int
 // Window stubs
 STUB_RETURN_ZERO(window_get_fullscreen)
 STUB_RETURN_UNDEFINED(window_set_fullscreen)
-STUB_RETURN_UNDEFINED(window_set_size)
-STUB_RETURN_UNDEFINED(window_center)
 static RValue builtinWindowGetWidth(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
+    Runner* runner = (Runner*) ctx->runner;
+    if (runner != nullptr && runner->getWindowSize != nullptr) {
+        int32_t w = 0;
+        int32_t h = 0;
+        if (runner->getWindowSize(runner->nativeWindow, &w, &h)) {
+            return RValue_makeReal((GMLReal) w);
+        }
+    }
     return RValue_makeReal((GMLReal) ctx->dataWin->gen8.defaultWindowWidth);
 }
 
 static RValue builtinWindowGetHeight(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
+    Runner* runner = (Runner*) ctx->runner;
+    if (runner != nullptr && runner->getWindowSize != nullptr) {
+        int32_t w = 0;
+        int32_t h = 0;
+        if (runner->getWindowSize(runner->nativeWindow, &w, &h)) {
+            return RValue_makeReal((GMLReal) h);
+        }
+    }
     return RValue_makeReal((GMLReal) ctx->dataWin->gen8.defaultWindowHeight);
 }
+
+static RValue builtinWindowSetSize(VMContext* ctx, RValue* args, MAYBE_UNUSED int32_t argCount) {
+    if (argCount < 2) return RValue_makeUndefined();
+
+    Runner* runner = (Runner*) ctx->runner;
+    if (runner == nullptr) return RValue_makeUndefined();
+
+    int32_t width = RValue_toInt32(args[0]);
+    int32_t height = RValue_toInt32(args[1]);
+    if (width < 1) width = 1;
+    if (height < 1) height = 1;
+
+    if (runner->setWindowSize != nullptr) {
+        runner->setWindowSize(runner->nativeWindow, width, height);
+    }
+
+    return RValue_makeUndefined();
+}
+STUB_RETURN_UNDEFINED(window_center)
 
 static RValue builtinWindowSetCaption(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_UNUSED int32_t argCount) {
     char* val = RValue_toString(args[0]);
@@ -9408,10 +9441,10 @@ void VMBuiltins_registerAll(VMContext* ctx) {
     VM_registerBuiltin(ctx, "window_get_fullscreen", builtin_window_get_fullscreen);
     VM_registerBuiltin(ctx, "window_set_fullscreen", builtin_window_set_fullscreen);
     VM_registerBuiltin(ctx, "window_set_caption", builtinWindowSetCaption);
-    VM_registerBuiltin(ctx, "window_set_size", builtin_window_set_size);
-    VM_registerBuiltin(ctx, "window_center", builtin_window_center);
     VM_registerBuiltin(ctx, "window_get_width", builtinWindowGetWidth);
     VM_registerBuiltin(ctx, "window_get_height", builtinWindowGetHeight);
+    VM_registerBuiltin(ctx, "window_set_size", builtinWindowSetSize);
+    VM_registerBuiltin(ctx, "window_center", builtin_window_center);
     VM_registerBuiltin(ctx, "window_has_focus", builtinWindowHasFocus);
 
     // Game

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -3826,9 +3826,46 @@ static RValue builtin_audioDestroyStream(VMContext* ctx, RValue* args, MAYBE_UNU
     return RValue_makeReal(success ? 1.0 : -1.0);
 }
 
-// Application surface stubs
-STUB_RETURN_UNDEFINED(application_surface_enable)
-STUB_RETURN_UNDEFINED(application_surface_draw_enable)
+// Application surface
+static RValue builtin_application_surface_enable(VMContext* ctx, RValue* args, MAYBE_UNUSED int32_t argCount) {
+    Runner* runner = (Runner*) ctx->runner;
+    if (runner == nullptr || argCount < 1) return RValue_makeUndefined();
+
+    bool enable = RValue_toReal(args[0]) > 0.5;
+    if (runner->appSurfaceEnabled) {
+        runner->oldApplicationWidth = runner->applicationWidth;
+        runner->oldApplicationHeight = runner->applicationHeight;
+    }
+
+    runner->appSurfaceEnabled = enable;
+    runner->usingAppSurface = enable;
+
+    if (!enable) {
+        int32_t w = runner->applicationWidth;
+        int32_t h = runner->applicationHeight;
+        if (runner->getWindowSize != nullptr && runner->getWindowSize(runner->nativeWindow, &w, &h) && w > 0 && h > 0) {
+            runner->applicationWidth = w;
+            runner->applicationHeight = h;
+        }
+    } else {
+        if (runner->oldApplicationWidth > 0 && runner->oldApplicationHeight > 0) {
+            runner->applicationWidth = runner->oldApplicationWidth;
+            runner->applicationHeight = runner->oldApplicationHeight;
+        } else {
+            runner->applicationWidth = (int32_t) ctx->dataWin->gen8.defaultWindowWidth;
+            runner->applicationHeight = (int32_t) ctx->dataWin->gen8.defaultWindowHeight;
+        }
+    }
+
+    return RValue_makeUndefined();
+}
+
+static RValue builtin_application_surface_draw_enable(VMContext* ctx, RValue* args, MAYBE_UNUSED int32_t argCount) {
+    Runner* runner = (Runner*) ctx->runner;
+    if (runner == nullptr || argCount < 1) return RValue_makeUndefined();
+    runner->appSurfaceAutoDraw = RValue_toReal(args[0]) > 0.5;
+    return RValue_makeUndefined();
+}
 
 // ===[ Gamepad Functions ]===
 static RValue builtinGamepadGetDeviceCount(VMContext* ctx, RValue* args, int32_t argCount) {
@@ -6490,6 +6527,9 @@ static RValue builtinSurfaceGetWidth(VMContext* ctx, RValue* args, MAYBE_UNUSED 
     int32_t surfaceId = (int32_t) RValue_toReal(args[0]);
     Runner* runner = (Runner*) ctx->runner;
     if (surfaceId == -1) {
+        if (runner != nullptr && runner->applicationWidth > 0) {
+            return RValue_makeReal((GMLReal) runner->applicationWidth);
+        }
         return RValue_makeReal((GMLReal) ctx->dataWin->gen8.defaultWindowWidth);
     } else {
         return RValue_makeReal(Renderer_getSurfaceWidth(runner->renderer, surfaceId));
@@ -6502,6 +6542,9 @@ static RValue builtinSurfaceGetHeight(VMContext* ctx, RValue* args, MAYBE_UNUSED
     int32_t surfaceId = (int32_t) RValue_toReal(args[0]);
     Runner* runner = (Runner*) ctx->runner;
     if (surfaceId == -1) {
+        if (runner != nullptr && runner->applicationHeight > 0) {
+            return RValue_makeReal((GMLReal) runner->applicationHeight);
+        }
         return RValue_makeReal((GMLReal) ctx->dataWin->gen8.defaultWindowHeight);
     } else {
         return RValue_makeReal(Renderer_getSurfaceHeight(runner->renderer, surfaceId));

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -147,8 +147,9 @@ void* loop() {
 
         Runner_drawViews(gRunner, gameW, gameH, displayScaleX, displayScaleY, false);
         gRunner->renderer->vtable->endFrameInit(gRunner->renderer);
-        Runner_drawPost(gRunner, 640, 480, gameW, gameH);
+        Runner_drawPost(gRunner, 640, 480);
         gRunner->renderer->vtable->endFrameEnd(gRunner->renderer);
+        Runner_drawGUI(gRunner, 640, 480, gameW, gameH);
 
         // Just like glfwSwapBuffers.
         // Only swap when there isn't a room change to match the original runner.

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -146,6 +146,7 @@ void* loop() {
         glClear(GL_COLOR_BUFFER_BIT);
 
         Runner_drawViews(gRunner, gameW, gameH, displayScaleX, displayScaleY, false);
+        Runner_drawPost(gRunner);
 
         gRunner->renderer->vtable->endFrame(gRunner->renderer);
 

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -146,9 +146,8 @@ void* loop() {
         glClear(GL_COLOR_BUFFER_BIT);
 
         Runner_drawViews(gRunner, gameW, gameH, displayScaleX, displayScaleY, false);
-        Runner_drawPost(gRunner);
-
         gRunner->renderer->vtable->endFrame(gRunner->renderer);
+        Runner_drawPost(gRunner, 640, 480, gameW, gameH);
 
         // Just like glfwSwapBuffers.
         // Only swap when there isn't a room change to match the original runner.

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -130,6 +130,7 @@ void* loop() {
         float displayScaleX;
         float displayScaleY;
 
+        Runner_drawPre(gRunner, 640, 480);
         Runner_computeViewDisplayScale(gRunner, gameW, gameH, &displayScaleX, &displayScaleY);
 
         gRunner->renderer->vtable->beginFrame(gRunner->renderer, gameW, gameH, 640, 480);

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -146,8 +146,9 @@ void* loop() {
         glClear(GL_COLOR_BUFFER_BIT);
 
         Runner_drawViews(gRunner, gameW, gameH, displayScaleX, displayScaleY, false);
-        gRunner->renderer->vtable->endFrame(gRunner->renderer);
+        gRunner->renderer->vtable->endFrameInit(gRunner->renderer);
         Runner_drawPost(gRunner, 640, 480, gameW, gameH);
+        gRunner->renderer->vtable->endFrameEnd(gRunner->renderer);
 
         // Just like glfwSwapBuffers.
         // Only swap when there isn't a room change to match the original runner.


### PR DESCRIPTION
Split DRAW_POST out of the main draw flow to fix Undertale border/surface rendering issues and align behavior with the decompiled yoyo runner.

Implement proper glfw window dimension handling (window_get_width/height + window_set_size).

Implement application_surface_enable and application_surface_draw_enable builtins to control application surface usage and auto-draw behavior.

<img width="1668" height="640" alt="image" src="https://github.com/user-attachments/assets/f3dda292-8c59-4b7a-91bc-54ad5011dcbf" />
