### PR TITLE
Re-implement spriteless background layers + partial alpha support

### DIFF
--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -1358,7 +1358,7 @@ int main(int argc, char* argv[]) {
             int gInt = BGR_G(runner->backgroundColor);
             int bInt = BGR_B(runner->backgroundColor);
             int aInt = BGR_A(runner->backgroundColor);
-            // glClearColor(rInt / 255.0f, gInt / 255.0f, bInt / 255.0f, aInt / 255.0f);
+            glClearColor(rInt / 255.0f, gInt / 255.0f, bInt / 255.0f, aInt / 255.0f);
         } else {
             glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         }

--- a/src/glfw/main.c
+++ b/src/glfw/main.c
@@ -1357,7 +1357,8 @@ int main(int argc, char* argv[]) {
             int rInt = BGR_R(runner->backgroundColor);
             int gInt = BGR_G(runner->backgroundColor);
             int bInt = BGR_B(runner->backgroundColor);
-            glClearColor(rInt / 255.0f, gInt / 255.0f, bInt / 255.0f, 1.0f);
+            int aInt = BGR_A(runner->backgroundColor);
+            // glClearColor(rInt / 255.0f, gInt / 255.0f, bInt / 255.0f, aInt / 255.0f);
         } else {
             glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         }

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -643,7 +643,8 @@ int main(int argc, char* argv[]) {
             uint8_t bgR = BGR_R(runner->backgroundColor);
             uint8_t bgG = BGR_G(runner->backgroundColor);
             uint8_t bgB = BGR_B(runner->backgroundColor);
-            u64 bgColor = GS_SETREG_RGBAQ(bgR, bgG, bgB, 0x80, 0x00);
+            uint8_t bgA = BGR_A(runner->backgroundColor);
+            u64 bgColor = GS_SETREG_RGBAQ(bgR, bgG, bgB, bgA, 0x00);
             gsKit_prim_sprite(gsGlobal, 0, 0, 640, 448, 0, bgColor);
         }
 

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -410,7 +410,8 @@ int main(int argc, char* argv[]) {
             int rInt = BGR_R(runner->backgroundColor);
             int gInt = BGR_G(runner->backgroundColor);
             int bInt = BGR_B(runner->backgroundColor);
-            glClearColor(rInt / 255.0f, gInt / 255.0f, bInt / 255.0f, 1.0f);
+            int aInt = BGR_A(runner->backgroundColor);
+            glClearColor(rInt / 255.0f, gInt / 255.0f, bInt / 255.0f, aInt / 255.0f);
         } else {
             glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         }

--- a/src/runner.c
+++ b/src/runner.c
@@ -830,6 +830,7 @@ void Runner_draw(Runner* runner) {
 
                 if (0 > data->spriteIndex) {
                     // Spriteless background layer: draw as a colored rectangle with the layer's color/alpha
+                    // TODO: Match GMS's renering more closely (see PR #120)
                     float alpha = (float) BGR_A(data->color) / 255.0f;
                     runner->renderer->vtable->drawRectangle(runner->renderer, 0.0f, 0.0f, roomW, roomH, data->color, alpha, false);
                     continue;

--- a/src/runner.c
+++ b/src/runner.c
@@ -725,6 +725,11 @@ void Runner_draw(Runner* runner) {
                     if (layerElement->type == RuntimeLayerElementType_Background && layerElement->backgroundElement != nullptr) {
                         RuntimeBackgroundElement* bg = layerElement->backgroundElement;
                         if (!bg->visible) continue;
+                        if (0 > bg->spriteIndex) {
+                            // Spriteless background element: draw as a colored rectangle
+                            runner->renderer->vtable->drawRectangle(runner->renderer, 0.0f, 0.0f, roomW, roomH, bg->blend, bg->alpha, false);
+                            continue;
+                        }
                         int32_t tpagIndex = Renderer_resolveSpriteTPAGIndex(dataWin, bg->spriteIndex);
                         if (0 > tpagIndex) continue;
                         if (bg->stretch) {
@@ -818,26 +823,33 @@ void Runner_draw(Runner* runner) {
                 }
             } else if(parsedLayer->type == RoomLayerType_Background) {
                 if (runner->renderer == nullptr) return;
-                    DataWin* dataWin = runner->dataWin;
-                    float roomW = (float) runner->currentRoom->width;
-                    float roomH = (float) runner->currentRoom->height;
-                    RoomLayerBackgroundData* data = parsedLayer->backgroundData;
+                DataWin* dataWin = runner->dataWin;
+                float roomW = (float) runner->currentRoom->width;
+                float roomH = (float) runner->currentRoom->height;
+                RoomLayerBackgroundData* data = parsedLayer->backgroundData;
 
-                        int32_t tpagIndex = Renderer_resolveSpriteTPAGIndex(dataWin, data->spriteIndex);
-                        if (0 > tpagIndex) continue;
+                if (0 > data->spriteIndex) {
+                    // Spriteless background layer: draw as a colored rectangle with the layer's color/alpha
+                    float alpha = (float) BGR_A(data->color) / 255.0f;
+                    runner->renderer->vtable->drawRectangle(runner->renderer, 0.0f, 0.0f, roomW, roomH, data->color, alpha, false);
+                    continue;
+                }
 
-                        if (data->stretch) {
-                            // Stretch to fill room dimensions
-                            TexturePageItem* tpag = &dataWin->tpag.items[tpagIndex];
-                            float xscale = roomW / (float) tpag->boundingWidth;
-                            float yscale = roomH / (float) tpag->boundingHeight;
-                            runner->renderer->vtable->drawSprite(runner->renderer, tpagIndex, 0.0f, 0.0f, 0.0f, 0.0f, xscale, yscale, 0.0f, 0xFFFFFF, 1.0);
-                        } else if (data->hTiled || data->vTiled) {
-                            Renderer_drawBackgroundTiled(runner->renderer, tpagIndex, layerOffsetX, layerOffsetY, data->hTiled, data->vTiled, roomW, roomH, 1.0);
-                        } else {
-                            // Single placement
-                            runner->renderer->vtable->drawSprite(runner->renderer, tpagIndex, layerOffsetX, layerOffsetY, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0xFFFFFF, 1.0);
-                        }
+                int32_t tpagIndex = Renderer_resolveSpriteTPAGIndex(dataWin, data->spriteIndex);
+                if (0 > tpagIndex) continue;
+
+                if (data->stretch) {
+                    // Stretch to fill room dimensions
+                    TexturePageItem* tpag = &dataWin->tpag.items[tpagIndex];
+                    float xscale = roomW / (float) tpag->boundingWidth;
+                    float yscale = roomH / (float) tpag->boundingHeight;
+                    runner->renderer->vtable->drawSprite(runner->renderer, tpagIndex, 0.0f, 0.0f, 0.0f, 0.0f, xscale, yscale, 0.0f, 0xFFFFFF, 1.0);
+                } else if (data->hTiled || data->vTiled) {
+                    Renderer_drawBackgroundTiled(runner->renderer, tpagIndex, layerOffsetX, layerOffsetY, data->hTiled, data->vTiled, roomW, roomH, 1.0);
+                } else {
+                    // Single placement
+                    runner->renderer->vtable->drawSprite(runner->renderer, tpagIndex, layerOffsetX, layerOffsetY, 0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 0xFFFFFF, 1.0);
+                }
             } else if(parsedLayer->type == RoomLayerType_Instances) {
                 // Instance depth is assigned from layers during room init (initRoom).
                 // Nothing to do here - instances are drawn from the DRAWABLE_INSTANCE path.
@@ -1232,23 +1244,6 @@ static void initRoom(Runner* runner, int32_t roomIndex) {
         dst->speedY = (float) src->speedY;
         dst->stretch = src->stretch;
         dst->alpha = 1.0f;
-    }
-
-    // If the room contains a visible Background layer with no sprite, use that layer's color
-    // as the background color when initializing the room.
-    int32_t bestDepth = 0;
-    uint32_t bestColor = 0;
-    repeat(room->layerCount, i) {
-        RoomLayer* layerSource = &room->layers[i];
-        if (layerSource->type != RoomLayerType_Background || layerSource->backgroundData == nullptr) continue;
-        RoomLayerBackgroundData* data = layerSource->backgroundData;
-        if (!data->visible || data->spriteIndex >= 0) continue;
-        if (layerSource->depth > bestDepth) {
-            bestDepth = layerSource->depth;
-            bestColor = data->color;
-            runner->backgroundColor = bestColor;
-            runner->drawBackgroundColor = true;
-        }
     }
 
     Instance** carriedPersistent = takePersistentInstances(runner);

--- a/src/utils.h
+++ b/src/utils.h
@@ -117,6 +117,7 @@ static inline GMLReal clampFloat(GMLReal f) {
 #define BGR_B(c) (((c) >> 16) & 0xFF)
 #define BGR_G(c) (((c) >>  8) & 0xFF)
 #define BGR_R(c) (((c) >>  0) & 0xFF)
+#define BGR_A(c) (((c) >> 24) & 0xFF)
 
 // Mixes 2 colors with a blend factor
 static inline int32_t Color_lerp(int32_t color1, int32_t color2, float blending) {

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -139,7 +139,8 @@ void* loop() {
             int rInt = BGR_R(gRunner->backgroundColor);
             int gInt = BGR_G(gRunner->backgroundColor);
             int bInt = BGR_B(gRunner->backgroundColor);
-            glClearColor(rInt / 255.0f, gInt / 255.0f, bInt / 255.0f, 1.0f);
+            int aInt = BGR_A(gRunner->backgroundColor);
+            glClearColor(rInt / 255.0f, gInt / 255.0f, bInt / 255.0f, aInt / 255.0f);
         } else {
             glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         }


### PR DESCRIPTION
Re-implements the changes in #111 with additional partial support for background colors with alpha levels != 1.

This implementation is an improvement from before, but is not 100% accurate. When using a transparent background, the GMS 2022.9 runner will gradually increase the alpha of the background until it is opaque. Frankly, I'm unsure why the official runner would do this, but this behavior has not been replicated in this PR.

Test program: [game.ios.zip](https://github.com/user-attachments/files/27770704/game.ios.zip)
This program uses one semi-transparent red background and one semi-transparent blue background.


| GMS 2022.9 |  Butterscotch (Before) | Butterscotch (After) |
| -------- | ------- | ------- |
| <img width="1112" height="840" src="https://github.com/user-attachments/assets/44083c9f-20e5-4976-9a20-4a4ad23a8dd1" /> | <img width="1112" height="844" alt="Screenshot 2026-05-14 at 1 56 22 PM" src="https://github.com/user-attachments/assets/f617fd53-b8dc-4556-b09d-da12283b0504" /> | <img width="1112" height="844" src="https://github.com/user-attachments/assets/9f7b3bbd-4c00-4a40-acc7-00edb1c43c16" /> |