### PR TITLE
fix stupid typo also move macro to other header

### DIFF
--- a/src/binary_utils.h
+++ b/src/binary_utils.h
@@ -1,13 +1,10 @@
 #pragma once
 
 #include "common.h"
+#include "endianness.h"
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-
-#if (defined(__BYTE__ORDER__) && (__BYTE__ORDER__ == __ORDER_BIG_ENDIAN__)) || defined(__BIG_ENDIAN__)
-#define IS_BIG_ENDIAN
-#endif
 
 // Binary reads/writes from a raw byte buffer.
 // When IS_BIG_ENDIAN is defined, reads are byte-swapped to interpret serialized little-endian data.

--- a/src/binary_utils.h
+++ b/src/binary_utils.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "common.h"
-#include "endianness.h"
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/common.h
+++ b/src/common.h
@@ -5,6 +5,10 @@
 #define nullptr NULL
 #endif
 
+#if (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || defined(__BIG_ENDIAN__)
+#define IS_BIG_ENDIAN
+#endif
+
 #if defined(__has_c_attribute)
     #if __has_c_attribute(maybe_unused)
         #define MAYBE_UNUSED [[maybe_unused]]

--- a/src/endianness.h
+++ b/src/endianness.h
@@ -1,5 +1,0 @@
-#pragma once
-
-#if (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || defined(__BIG_ENDIAN__)
-#define IS_BIG_ENDIAN
-#endif

--- a/src/endianness.h
+++ b/src/endianness.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#if (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || defined(__BIG_ENDIAN__)
+#define IS_BIG_ENDIAN
+#endif

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -9455,7 +9455,7 @@ static RValue builtin_json_decode(VMContext* ctx, RValue* args, int32_t argCount
     int32_t mapIndex = dsMapCreate(runner);
     DsMapEntry **mapPtr = dsMapGet(runner, mapIndex);
     const char* content = args[0].string;
-    const JsonValue* json = JsonReader_parse(content);
+    JsonValue* json = JsonReader_parse(content);
 
     repeat(JsonReader_objectLength(json), i) {
         const char *key = safeStrdup(JsonReader_getObjectKey(json, i));


### PR DESCRIPTION
`__BYTE__ORDER__` is only supposed to have one underscore in the middle.
also moved the macro to another header so it's easy to use in other places (like the software renderer pixel conversion code)