### PR TITLE
Better dependency handling in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,14 +172,20 @@ endif
 
 OBJS := $(addprefix build/,$(SRCS:.c=.c.o))
 
+ifndef DISABLE_MMD
+DEPFLAGS = -MMD -MP
+endif
+
 all: build/butterscotch
+
+-include $(OBJS:.o=.d)
 
 build/butterscotch: $(OBJS)
 	$(CC) $(LDFLAGS) $(OBJS) $(LIBS) $(EXTRALIBS) -o $@
 
-build/%.c.o: %.c $(HEADERS)
+build/%.c.o: %.c $(if $(DISABLE_MMD),$(HEADERS))
 	@mkdir -p $(dir $@)
-	$(CC) $(DEFINES) $(INCLUDES) $(CFLAGS) -c $< -o $@
+	$(CC) $(DEFINES) $(INCLUDES) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
 clean:
 	rm -rf build

--- a/src/sdl/main.c
+++ b/src/sdl/main.c
@@ -844,7 +844,7 @@ int main(int argc, char* argv[]) {
     fbWidth = reqW;
     fbHeight = reqH;
     if(!args.headless) {
-        scr = SDL_SetVideoMode(reqW, reqH, 0, useSWRend ? 0 : (SDL_OPENGL | SDL_RESIZABLE));
+        scr = SDL_SetVideoMode(fbWidth, fbHeight, 0, useSWRend ? 0 : (SDL_OPENGL | SDL_RESIZABLE));
         if (!scr && useSWRend) {
             SDL_Rect** modes = SDL_ListModes(NULL, SDL_FULLSCREEN);
             if (modes && modes != (SDL_Rect**) -1 && modes[0]) {


### PR DESCRIPTION
Prevents having to do a full rebuild after changing any header.  Also adds an option DISABLE_MMD to use the old system if your compiler is weird and doesn't support the `-MMD -MP` arguments.