### PR TITLE
Fix stderr being buffered on windows

### DIFF
--- a/src/sdl/main.c
+++ b/src/sdl/main.c
@@ -645,6 +645,8 @@ static void onCrashSignal(int sig) {
 // ===[ MAIN ]===
 static bool shouldExit = false;
 int main(int argc, char* argv[]) {
+    setbuf(stderr, NULL);
+
     CommandLineArgs args;
     parseCommandLineArgs(&args, argc, argv);
 


### PR DESCRIPTION
On Windows, SDL 1.2 may call freopen() on stdout and stderr to make them output to files instead of a terminal.  In these cases, stderr might be buffered instead of unbuffered like it should, which means output might be lost if abort() is called.  This setbuf call ensures the stream is always unbuffered, and is effectively a nop if stderr is already unbuffered.