### PR TITLE
Implement environment_get_variable

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -3267,6 +3267,20 @@ static RValue builtin_os_get_region(MAYBE_UNUSED VMContext* ctx, MAYBE_UNUSED RV
 
 STUB_RETURN_FALSE(os_is_paused);
 
+static RValue builtin_environment_get_variable(MAYBE_UNUSED VMContext* ctx, RValue* args, int32_t argCount) {
+    char* name = RValue_toString(args[0]);
+    if (name == nullptr) return RValue_makeOwnedString(safeStrdup(""));
+
+    const char* value = getenv(name);
+    free(name);
+
+    if (value == nullptr) {
+        return RValue_makeOwnedString(safeStrdup(""));
+    }
+
+    return RValue_makeOwnedString(safeStrdup(value));
+}
+
 // ===[ DS_MAP BUILTIN FUNCTIONS ]===
 
 static inline ptrdiff_t getValueIndexInMap(DsMapEntry** mapPtr, RValue keyRvalue) {
@@ -11521,6 +11535,7 @@ void VMBuiltins_registerAll(VMContext* ctx) {
     VM_registerBuiltin(ctx, "os_get_language", builtin_os_get_language);
     VM_registerBuiltin(ctx, "os_get_region", builtin_os_get_region);
     VM_registerBuiltin(ctx, "os_is_paused", builtin_os_is_paused);
+    VM_registerBuiltin(ctx, "environment_get_variable", builtin_environment_get_variable);
 
     // ds_map
     VM_registerBuiltin(ctx, "ds_map_create", builtin_ds_map_create);


### PR DESCRIPTION
Self explanatory, used by SONIC.EXE to get the username (spooky)

<img width="642" height="512" alt="image" src="https://github.com/user-attachments/assets/06c94f74-1387-403d-bb31-cfcfb8f44739" />
