### PR TITLE
Slight revisions to the desktop platform API

### DIFF
--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -215,8 +215,10 @@ double platformGetTime(void) {
 }
 
 bool platformHandleEvents(void) {
+    if (!glfwGetWindowParam(GLFW_OPENED))
+        return true;
     glfwPollEvents();
-    return !glfwGetWindowParam(GLFW_OPENED);
+    return false;
 }
 
 void platformSleepUntil(double time) {

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -158,9 +158,6 @@ void platformExit(void) {
 
 void platformInitFunctions(Runner *runner) {
     g_runner = runner;
-    runner->setWindowTitle = platformSetWindowTitle;
-    runner->getWindowSize = platformGetWindowSize;
-    runner->setWindowSize = platformSetWindowSize;
     runner->windowHasFocus = platformGetWindowFocus;
 #ifdef ENABLE_SW_RENDERER
     if (gfx == SOFTWARE)

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -236,7 +236,3 @@ void platformSleepUntil(double time) {
         // Spin-wait for the remaining sub-millisecond
     }
 }
-
-void platformGamepad_poll(RunnerGamepadState* gp) {
-    (void)gp;
-}

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -45,7 +45,7 @@ void platformSetWindowSize(int32_t width, int32_t height) {
     if (width <= 0 || height <= 0) return;
     if (!window) return;
     float xs = 1.0f, ys = 1.0f;
-    glfwGetWindowContentScale((GLFWwindow*) window, &xs, &ys);
+    glfwGetWindowContentScale(window, &xs, &ys);
     int logicalW, logicalH;
     framebufferToLogical(xs, ys, width, height, &logicalW, &logicalH);
     glfwSetWindowSize(window, logicalW, logicalH);

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -313,6 +313,9 @@ static void mapGlfwToGml(const GLFWgamepadstate* glfwState, GamepadSlot* slot) {
 }
 
 bool platformHandleEvents(void) {
+    if (glfwWindowShouldClose(window))
+        return true;
+
     glfwPollEvents();
 
     for (int slotIdx = 0; slotIdx < 1 && slotIdx < MAX_GAMEPADS; slotIdx++) {
@@ -368,7 +371,7 @@ bool platformHandleEvents(void) {
         }
     }
 
-    return glfwWindowShouldClose(window);
+    return false;
 }
 
 void platformSleepUntil(double time) {

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -209,9 +209,6 @@ void platformExit(void) {
 
 void platformInitFunctions(Runner *runner) {
     g_runner = runner;
-    runner->setWindowTitle = platformSetWindowTitle;
-    runner->getWindowSize = platformGetWindowSize;
-    runner->setWindowSize = platformSetWindowSize;
     runner->windowHasFocus = platformGetWindowFocus;
 #ifdef ENABLE_SW_RENDERER
     if (gfx == SOFTWARE)

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -316,7 +316,7 @@ bool platformHandleEvents(void) {
     glfwPollEvents();
 
     for (int slotIdx = 0; slotIdx < 1 && slotIdx < MAX_GAMEPADS; slotIdx++) {
-        GamepadSlot* slot = g_runner->gamepads->slots[slotIdx];
+        GamepadSlot* slot = g_runner->gamepads->slots + slotIdx;
 
         bool currentlyConnected = false;
         int  foundJid = -1;

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -244,29 +244,6 @@ double platformGetTime(void) {
     return glfwGetTime();
 }
 
-bool platformHandleEvents(void) {
-    glfwPollEvents();
-    return glfwWindowShouldClose(window);
-}
-
-void platformSleepUntil(double time) {
-    double remaining = time - platformGetTime();
-    if (remaining > 0.002) {
-#ifdef _WIN32
-        Sleep((DWORD) ((remaining - 0.001) * 1000));
-#else
-        struct timespec ts = {
-            .tv_sec = 0,
-            .tv_nsec = (long) ((remaining - 0.001) * 1e9)
-        };
-        nanosleep(&ts, NULL);
-#endif
-    }
-    while (platformGetTime() < time) {
-        // Spin-wait for the remaining sub-millisecond
-    }
-}
-
 static float applyDeadzone(float value, float deadzone) {
     if (value < 0.0f) {
         if (value > -deadzone) return 0.0f;
@@ -335,9 +312,11 @@ static void mapGlfwToGml(const GLFWgamepadstate* glfwState, GamepadSlot* slot) {
     }
 }
 
-void platformGamepad_poll(RunnerGamepadState* gp) {
+bool platformHandleEvents(void) {
+    glfwPollEvents();
+
     for (int slotIdx = 0; slotIdx < 1 && slotIdx < MAX_GAMEPADS; slotIdx++) {
-        GamepadSlot* slot = &gp->slots[slotIdx];
+        GamepadSlot* slot = g_runner.gamepads->slots[slotIdx];
 
         bool currentlyConnected = false;
         int  foundJid = -1;
@@ -385,7 +364,27 @@ void platformGamepad_poll(RunnerGamepadState* gp) {
                 if (slot->buttonDown[btn] && !wasDown) slot->buttonPressed[btn] = true;
                 if (!slot->buttonDown[btn] && wasDown) slot->buttonReleased[btn] = true;
             }
-            gp->connectedCount++;
+            g_runner->gamepads->connectedCount++;
         }
+    }
+
+    return glfwWindowShouldClose(window);
+}
+
+void platformSleepUntil(double time) {
+    double remaining = time - platformGetTime();
+    if (remaining > 0.002) {
+#ifdef _WIN32
+        Sleep((DWORD) ((remaining - 0.001) * 1000));
+#else
+        struct timespec ts = {
+            .tv_sec = 0,
+            .tv_nsec = (long) ((remaining - 0.001) * 1e9)
+        };
+        nanosleep(&ts, NULL);
+#endif
+    }
+    while (platformGetTime() < time) {
+        // Spin-wait for the remaining sub-millisecond
     }
 }

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -316,7 +316,7 @@ bool platformHandleEvents(void) {
     glfwPollEvents();
 
     for (int slotIdx = 0; slotIdx < 1 && slotIdx < MAX_GAMEPADS; slotIdx++) {
-        GamepadSlot* slot = g_runner.gamepads->slots[slotIdx];
+        GamepadSlot* slot = g_runner->gamepads->slots[slotIdx];
 
         bool currentlyConnected = false;
         int  foundJid = -1;

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -182,7 +182,6 @@ static int32_t SDLKeyToGml(int sdlkey) {
 }
 
 bool platformHandleEvents(void) {
-    bool should_exit = false;
     SDL_Event e;
     while (SDL_PollEvent(&e)) {
         switch(e.type) {
@@ -204,14 +203,13 @@ bool platformHandleEvents(void) {
                 scr = SDL_SetVideoMode(fbWidth, fbHeight, 0, (gfx == SOFTWARE ? 0 : SDL_OPENGL) | SDL_RESIZABLE);
                 break;
             case SDL_QUIT:
-                should_exit = true;
-                break;
+                return true;
             default:
                 break;
         }
     }
 
-    return should_exit;
+    return false;
 }
 
 void platformSleepUntil(double time) {

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -82,9 +82,6 @@ void platformExit(void) {
 
 void platformInitFunctions(Runner *runner) {
     g_runner = runner;
-    runner->setWindowTitle = platformSetWindowTitle;
-    runner->getWindowSize = platformGetWindowSize;
-    runner->setWindowSize = platformSetWindowSize;
     runner->windowHasFocus = platformGetWindowFocus;
 }
 

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -223,7 +223,3 @@ void platformSleepUntil(double time) {
         // Spin-wait for the remaining sub-millisecond
     }
 }
-
-void platformGamepad_poll(RunnerGamepadState* gp) {
-    (void)gp;
-}

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -1057,6 +1057,9 @@ int main(int argc, char* argv[]) {
         Runner* runner = Runner_create(dataWin, vm, renderer, (FileSystem*) overlayFs, audioSystem);
         runner->debugMode = args.debug;
         runner->osType = args.osType;
+        runner->setWindowSize = platformSetWindowSize;
+        runner->getWindowSize = platformGetWindowSize;
+        runner->setWindowTitle = platformSetWindowTitle;
         Runner_setGameArgs(runner, currentGameArgs, (int32_t) arrlen(currentGameArgs));
         platformInitFunctions(runner);
 

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -1116,7 +1116,6 @@ int main(int argc, char* argv[]) {
             RunnerGamepad_beginFrame(runner->gamepads);
             if (platformHandleEvents())
                 shouldWindowClose = true;
-            platformGamepad_poll(runner->gamepads);
 
             // Debug key bindings
             if (runner->debugMode) {

--- a/src/desktop/platformdefs.h
+++ b/src/desktop/platformdefs.h
@@ -13,7 +13,6 @@ void *platformGetProcAddress(const char *name);
 double platformGetTime(void);
 bool platformHandleEvents(void);
 bool platformGetWindowSize(int32_t* outW, int32_t* outH);
-void platformGamepad_poll(RunnerGamepadState* gp);
 void platformSleepUntil(double time);
 
 enum gfx_api {


### PR DESCRIPTION
- Inlined platformGamepad_poll into platformHandleEvents.
  - Saves APIs that don't support gamepads from having to add stub functions, was only ever called once anyway in the same spot as platformHandleEvents.
- Returns immediately on exit condition in all backends.
  - No point to doing work of handling other events if we're about to exit.
- Moves initialization of non-optional runner functions to the main file instead of doing it in backend files.