### PR TITLE
Don't bother explicitly disabling vsync in SDL 1.2

### DIFF
--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -52,8 +52,6 @@ bool platformInit(int reqW, int reqH, const char *title, bool headless) {
     fbWidth = reqW;
     fbHeight = reqH;
     if(!headless) {
-        if (gfx == LEGACY_GL || gfx == MODERN_GL)
-            SDL_GL_SetAttribute(SDL_GL_SWAP_CONTROL, 0); // disable vsync
         scr = SDL_SetVideoMode(fbWidth, fbHeight, 0, (gfx == SOFTWARE ? 0 : SDL_OPENGL) | SDL_RESIZABLE);
         if (!scr && gfx == SOFTWARE) {
             SDL_Rect** modes = SDL_ListModes(NULL, SDL_FULLSCREEN);

--- a/src/int_rvalue_hashmap.c
+++ b/src/int_rvalue_hashmap.c
@@ -81,7 +81,7 @@ RValue* IntRValueHashMap_getOrInsertUndefined(IntRValueHashMap* map, int32_t key
         if (slotKey == key) return &map->entries[idx].value;
         if (slotKey == INT_RVALUE_HASHMAP_EMPTY_KEY) {
             map->entries[idx].key = key;
-            map->entries[idx].value = (RValue){ .type = RVALUE_UNDEFINED };
+            map->entries[idx].value = RValue_makeUndefined();
             map->count++;
             return &map->entries[idx].value;
         }

--- a/src/int_rvalue_hashmap.h
+++ b/src/int_rvalue_hashmap.h
@@ -45,7 +45,7 @@ static inline uint32_t IntRValueHashMap_count(const IntRValueHashMap* map) {
 
 // Fast inline get. Returns a non-owning (weak) view of the value, or RVALUE_UNDEFINED if absent. Caller must NOT RValue_free the result without first strengthening it (strdup / incRef).
 static inline RValue IntRValueHashMap_get(const IntRValueHashMap* map, int32_t key) {
-    if (map->capacity == 0) return (RValue){ .type = RVALUE_UNDEFINED };
+    if (map->capacity == 0) return RValue_makeUndefined();
     const IntRValueEntry* entries = map->entries;
     uint32_t mask = map->mask;
     uint32_t idx = ((uint32_t) key * 0x9E3779B9u) & mask;
@@ -56,7 +56,7 @@ static inline RValue IntRValueHashMap_get(const IntRValueHashMap* map, int32_t k
             result.ownsReference = false;
             return result;
         }
-        if (slotKey == INT_RVALUE_HASHMAP_EMPTY_KEY) return (RValue){ .type = RVALUE_UNDEFINED };
+        if (slotKey == INT_RVALUE_HASHMAP_EMPTY_KEY) return RValue_makeUndefined();
         idx = (idx + 1) & mask;
     }
 }

--- a/src/runner.c
+++ b/src/runner.c
@@ -3328,7 +3328,7 @@ static void writeRValueJson(JsonWriter* w, RValue val) {
             if (val.array != nullptr) {
                 repeat(GMLArray_length1D(val.array), ai) {
                     RValue* cell = GMLArray_slot(val.array, ai);
-                    writeRValueJson(w, cell != nullptr ? *cell : (RValue){ .type = RVALUE_UNDEFINED });
+                    writeRValueJson(w, cell != nullptr ? *cell : RValue_makeUndefined());
                 }
             }
             JsonWriter_endArray(w);

--- a/src/vm.c
+++ b/src/vm.c
@@ -247,11 +247,11 @@ static Instance* findInstanceByTarget(VMContext* ctx, int32_t target);
 // The returned RValue is a weak view, callers that stash it must strengthen (incRef, strdup).
 static RValue VM_arrayReadAt(RValue* slot, int32_t index) {
     if (slot == nullptr || slot->type != RVALUE_ARRAY || slot->array == nullptr) {
-        return (RValue){ .type = RVALUE_UNDEFINED };
+        return RValue_makeUndefined();
     }
     RValue* cell = GMLArray_slot(slot->array, index);
     if (cell == nullptr) {
-        return (RValue){ .type = RVALUE_UNDEFINED };
+        return RValue_makeUndefined();
     }
     RValue result = *cell;
     result.ownsReference = false;
@@ -458,7 +458,7 @@ static uint32_t growGlobalSlotSparse(VMContext* ctx, int32_t varKey) {
             ctx->globalVarCapacity = newCap;
         }
         for (uint32_t i = ctx->globalVarCount; slot >= i; i++) {
-            ctx->globalVars[i] = (RValue){ .type = RVALUE_UNDEFINED };
+            ctx->globalVars[i] = RValue_makeUndefined();
         }
         ctx->globalVarCount = slot + 1;
     }
@@ -496,7 +496,7 @@ static uint32_t resolveLocalSlot(VMContext* ctx, int32_t varID) {
     // Pre-existing entries can still be past ctx->localVarCount if a nested call to the same code extended the slot map while the outer frame was suspended (the outer frame's localVarCount is captured at call entry and doesn't follow later growth).
     if (slot >= ctx->localVarCount) {
         for (uint32_t i = ctx->localVarCount; slot >= i; i++) {
-            ctx->localVars[i] = (RValue){ .type = RVALUE_UNDEFINED };
+            ctx->localVars[i] = RValue_makeUndefined();
         }
         ctx->localVarCount = slot + 1;
     }
@@ -534,7 +534,7 @@ static inline bool tryFastVarRead(VMContext* ctx, int32_t instanceType, Variable
             Instance* inst = (Instance*) ctx->currentInstance;
             if (inst == nullptr) return false;
             RValue* slot = IntRValueHashMap_findSlot(&inst->selfVars, varDef->varID);
-            *out = (slot != nullptr) ? *slot : (RValue){ .type = RVALUE_UNDEFINED };
+            *out = (slot != nullptr) ? *slot : RValue_makeUndefined();
             out->ownsReference = false;
             return true;
         }
@@ -556,7 +556,7 @@ static inline bool tryFastVarRead(VMContext* ctx, int32_t instanceType, Variable
             Instance* inst = (Instance*) ctx->otherInstance;
             if (inst == nullptr) return false;
             RValue* slot = IntRValueHashMap_findSlot(&inst->selfVars, varDef->varID);
-            *out = (slot != nullptr) ? *slot : (RValue){ .type = RVALUE_UNDEFINED };
+            *out = (slot != nullptr) ? *slot : RValue_makeUndefined();
             out->ownsReference = false;
             return true;
         }
@@ -833,7 +833,7 @@ static RValue resolveVariableRead(VMContext* ctx, int32_t instanceType, uint32_t
                     return staticVal;
                 }
 #endif
-                return (RValue){ .type = RVALUE_UNDEFINED };
+                return RValue_makeUndefined();
             }
             break;
         }


### PR DESCRIPTION
SDL 1.2 actually defaults to vsync off anyway, plus older version of SDL don't have the setting so it was causing issues building on some old systems.

Also replaces all inline RVALUE_UNDEFINED creations with RValue_makeUndefined()