### PR TITLE
GCC 2.95 support

### DIFF
--- a/src/audio/miniaudio/ma_audio_system.c
+++ b/src/audio/miniaudio/ma_audio_system.c
@@ -618,10 +618,9 @@ static void maGroupLoad(AudioSystem* audio, int32_t groupIndex) {
             return;
         }
 
-        DataWin *audioGroup = DataWin_parse(((MaAudioSystem*)audio)->fileSystem->vtable->resolvePath(((MaAudioSystem*)audio)->fileSystem, buf),
-        (DataWinParserOptions) {
-            .parseAudo = true,
-        });
+        DataWinParserOptions options = {0};
+        options.parseAudo = true;
+        DataWin *audioGroup = DataWin_parse(((MaAudioSystem*)audio)->fileSystem->vtable->resolvePath(((MaAudioSystem*)audio)->fileSystem, buf), options);
         arrput(audio->audioGroups, audioGroup);
     }
 }
@@ -697,37 +696,36 @@ static bool maDestroyStream(AudioSystem* audio, int32_t streamIndex) {
 
 // ===[ Vtable ]===
 
-static AudioSystemVtable maAudioSystemVtable = {
-    .init = maInit,
-    .destroy = maDestroy,
-    .update = maUpdate,
-    .playSound = maPlaySound,
-    .stopSound = maStopSound,
-    .stopAll = maStopAll,
-    .isPlaying = maIsPlaying,
-    .pauseSound = maPauseSound,
-    .resumeSound = maResumeSound,
-    .pauseAll = maPauseAll,
-    .resumeAll = maResumeAll,
-    .setSoundGain = maSetSoundGain,
-    .getSoundGain = maGetSoundGain,
-    .setSoundPitch = maSetSoundPitch,
-    .getSoundPitch = maGetSoundPitch,
-    .getTrackPosition = maGetTrackPosition,
-    .setTrackPosition = maSetTrackPosition,
-    .getSoundLength = maGetSoundLength,
-    .setMasterGain = maSetMasterGain,
-    .setChannelCount = maSetChannelCount,
-    .groupLoad = maGroupLoad,
-    .groupIsLoaded = maGroupIsLoaded,
-    .createStream = maCreateStream,
-    .destroyStream = maDestroyStream,
-};
+static AudioSystemVtable maAudioSystemVtable;
 
 // ===[ Lifecycle ]===
 
 MaAudioSystem* MaAudioSystem_create(void) {
     MaAudioSystem* ma = safeCalloc(1, sizeof(MaAudioSystem));
+    maAudioSystemVtable.init = maInit;
+    maAudioSystemVtable.destroy = maDestroy;
+    maAudioSystemVtable.update = maUpdate;
+    maAudioSystemVtable.playSound = maPlaySound;
+    maAudioSystemVtable.stopSound = maStopSound;
+    maAudioSystemVtable.stopAll = maStopAll;
+    maAudioSystemVtable.isPlaying = maIsPlaying;
+    maAudioSystemVtable.pauseSound = maPauseSound;
+    maAudioSystemVtable.resumeSound = maResumeSound;
+    maAudioSystemVtable.pauseAll = maPauseAll;
+    maAudioSystemVtable.resumeAll = maResumeAll;
+    maAudioSystemVtable.setSoundGain = maSetSoundGain;
+    maAudioSystemVtable.getSoundGain = maGetSoundGain;
+    maAudioSystemVtable.setSoundPitch = maSetSoundPitch;
+    maAudioSystemVtable.getSoundPitch = maGetSoundPitch;
+    maAudioSystemVtable.getTrackPosition = maGetTrackPosition;
+    maAudioSystemVtable.setTrackPosition = maSetTrackPosition;
+    maAudioSystemVtable.getSoundLength = maGetSoundLength;
+    maAudioSystemVtable.setMasterGain = maSetMasterGain;
+    maAudioSystemVtable.setChannelCount = maSetChannelCount;
+    maAudioSystemVtable.groupLoad = maGroupLoad;
+    maAudioSystemVtable.groupIsLoaded = maGroupIsLoaded;
+    maAudioSystemVtable.createStream = maCreateStream;
+    maAudioSystemVtable.destroyStream = maDestroyStream;
     ma->base.vtable = &maAudioSystemVtable;
     return ma;
 }

--- a/src/audio/openal/al_audio_system.c
+++ b/src/audio/openal/al_audio_system.c
@@ -790,10 +790,9 @@ static void maGroupLoad(AudioSystem* audio, int32_t groupIndex) {
             return;
         }
 
-        DataWin *audioGroup = DataWin_parse(((AlAudioSystem*)audio)->fileSystem->vtable->resolvePath(((AlAudioSystem*)audio)->fileSystem, buf),
-        (DataWinParserOptions) {
-            .parseAudo = true,
-        });
+        DataWinParserOptions options = {0};
+        options.parseAudo = true;
+        DataWin *audioGroup = DataWin_parse(((AlAudioSystem*)audio)->fileSystem->vtable->resolvePath(((AlAudioSystem*)audio)->fileSystem, buf), options);
         arrput(audio->audioGroups, audioGroup);
     }
 }
@@ -864,37 +863,36 @@ static bool maDestroyStream(AudioSystem* audio, int32_t streamIndex) {
 
 // ===[ Vtable ]===
 
-static AudioSystemVtable AlAudioSystemVtable = {
-    .init = maInit,
-    .destroy = maDestroy,
-    .update = maUpdate,
-    .playSound = maPlaySound,
-    .stopSound = maStopSound,
-    .stopAll = maStopAll,
-    .isPlaying = maIsPlaying,
-    .pauseSound = maPauseSound,
-    .resumeSound = maResumeSound,
-    .pauseAll = maPauseAll,
-    .resumeAll = maResumeAll,
-    .setSoundGain = maSetSoundGain,
-    .getSoundGain = maGetSoundGain,
-    .setSoundPitch = maSetSoundPitch,
-    .getSoundPitch = maGetSoundPitch,
-    .getTrackPosition = maGetTrackPosition,
-    .setTrackPosition = maSetTrackPosition,
-    .getSoundLength = maGetSoundLength,
-    .setMasterGain = maSetMasterGain,
-    .setChannelCount = maSetChannelCount,
-    .groupLoad = maGroupLoad,
-    .groupIsLoaded = maGroupIsLoaded,
-    .createStream = maCreateStream,
-    .destroyStream = maDestroyStream,
-};
+static AudioSystemVtable AlAudioSystemVtable;
 
 // ===[ Lifecycle ]===
 
 AlAudioSystem* AlAudioSystem_create(void) {
     AlAudioSystem* ma = safeCalloc(1, sizeof(AlAudioSystem));
+    AlAudioSystemVtable.init = maInit;
+    AlAudioSystemVtable.destroy = maDestroy;
+    AlAudioSystemVtable.update = maUpdate;
+    AlAudioSystemVtable.playSound = maPlaySound;
+    AlAudioSystemVtable.stopSound = maStopSound;
+    AlAudioSystemVtable.stopAll = maStopAll;
+    AlAudioSystemVtable.isPlaying = maIsPlaying;
+    AlAudioSystemVtable.pauseSound = maPauseSound;
+    AlAudioSystemVtable.resumeSound = maResumeSound;
+    AlAudioSystemVtable.pauseAll = maPauseAll;
+    AlAudioSystemVtable.resumeAll = maResumeAll;
+    AlAudioSystemVtable.setSoundGain = maSetSoundGain;
+    AlAudioSystemVtable.getSoundGain = maGetSoundGain;
+    AlAudioSystemVtable.setSoundPitch = maSetSoundPitch;
+    AlAudioSystemVtable.getSoundPitch = maGetSoundPitch;
+    AlAudioSystemVtable.getTrackPosition = maGetTrackPosition;
+    AlAudioSystemVtable.setTrackPosition = maSetTrackPosition;
+    AlAudioSystemVtable.getSoundLength = maGetSoundLength;
+    AlAudioSystemVtable.setMasterGain = maSetMasterGain;
+    AlAudioSystemVtable.setChannelCount = maSetChannelCount;
+    AlAudioSystemVtable.groupLoad = maGroupLoad;
+    AlAudioSystemVtable.groupIsLoaded = maGroupIsLoaded;
+    AlAudioSystemVtable.createStream = maCreateStream;
+    AlAudioSystemVtable.destroyStream = maDestroyStream;
     ma->base.vtable = &AlAudioSystemVtable;
     return ma;
 }

--- a/src/audio/ps2/ps2_audio_system.c
+++ b/src/audio/ps2/ps2_audio_system.c
@@ -1313,37 +1313,36 @@ static bool ps2DestroyStream(AudioSystem* audio, int32_t streamIndex) {
 
 // ===[ Vtable ]===
 
-static AudioSystemVtable ps2AudioSystemVtable = {
-    .init = ps2Init,
-    .destroy = ps2Destroy,
-    .update = ps2Update,
-    .playSound = ps2PlaySound,
-    .stopSound = ps2StopSound,
-    .stopAll = ps2StopAll,
-    .isPlaying = ps2IsPlaying,
-    .pauseSound = ps2PauseSound,
-    .resumeSound = ps2ResumeSound,
-    .pauseAll = ps2PauseAll,
-    .resumeAll = ps2ResumeAll,
-    .setSoundGain = ps2SetSoundGain,
-    .getSoundGain = ps2GetSoundGain,
-    .setSoundPitch = ps2SetSoundPitch,
-    .getSoundPitch = ps2GetSoundPitch,
-    .getTrackPosition = ps2GetTrackPosition,
-    .setTrackPosition = ps2SetTrackPosition,
-    .getSoundLength = ps2GetSoundLength,
-    .setMasterGain = ps2SetMasterGain,
-    .setChannelCount = ps2SetChannelCount,
-    .groupLoad = ps2GroupLoad,
-    .groupIsLoaded = ps2GroupIsLoaded,
-    .createStream = ps2CreateStream,
-    .destroyStream = ps2DestroyStream,
-};
+static AudioSystemVtable ps2AudioSystemVtable;
 
 // ===[ Lifecycle ]===
 
 Ps2AudioSystem* Ps2AudioSystem_create(void) {
     Ps2AudioSystem* ps2 = safeCalloc(1, sizeof(Ps2AudioSystem));
+    ps2AudioSystemVtable.init = ps2Init;
+    ps2AudioSystemVtable.destroy = ps2Destroy;
+    ps2AudioSystemVtable.update = ps2Update;
+    ps2AudioSystemVtable.playSound = ps2PlaySound;
+    ps2AudioSystemVtable.stopSound = ps2StopSound;
+    ps2AudioSystemVtable.stopAll = ps2StopAll;
+    ps2AudioSystemVtable.isPlaying = ps2IsPlaying;
+    ps2AudioSystemVtable.pauseSound = ps2PauseSound;
+    ps2AudioSystemVtable.resumeSound = ps2ResumeSound;
+    ps2AudioSystemVtable.pauseAll = ps2PauseAll;
+    ps2AudioSystemVtable.resumeAll = ps2ResumeAll;
+    ps2AudioSystemVtable.setSoundGain = ps2SetSoundGain;
+    ps2AudioSystemVtable.getSoundGain = ps2GetSoundGain;
+    ps2AudioSystemVtable.setSoundPitch = ps2SetSoundPitch;
+    ps2AudioSystemVtable.getSoundPitch = ps2GetSoundPitch;
+    ps2AudioSystemVtable.getTrackPosition = ps2GetTrackPosition;
+    ps2AudioSystemVtable.setTrackPosition = ps2SetTrackPosition;
+    ps2AudioSystemVtable.getSoundLength = ps2GetSoundLength;
+    ps2AudioSystemVtable.setMasterGain = ps2SetMasterGain;
+    ps2AudioSystemVtable.setChannelCount = ps2SetChannelCount;
+    ps2AudioSystemVtable.groupLoad = ps2GroupLoad;
+    ps2AudioSystemVtable.groupIsLoaded = ps2GroupIsLoaded;
+    ps2AudioSystemVtable.createStream = ps2CreateStream;
+    ps2AudioSystemVtable.destroyStream = ps2DestroyStream;
     ps2->base.vtable = &ps2AudioSystemVtable;
     ps2->masterGain = 1.0f;
     return ps2;

--- a/src/audio/web/web_audio_system.c
+++ b/src/audio/web/web_audio_system.c
@@ -580,10 +580,9 @@ static void webGroupLoad(AudioSystem* audio, int32_t groupIndex) {
             return;
         }
 
-        DataWin* audioGroup = DataWin_parse(
-            ma->fileSystem->vtable->resolvePath(ma->fileSystem, buf),
-            (DataWinParserOptions) { .parseAudo = true }
-        );
+        DataWinParserOptions options = {0};
+        options.parseAudo = true;
+        DataWin* audioGroup = DataWin_parse(ma->fileSystem->vtable->resolvePath(ma->fileSystem, buf), options);
         arrput(audio->audioGroups, audioGroup);
     }
 }
@@ -654,37 +653,36 @@ static bool webDestroyStream(AudioSystem* audio, int32_t streamIndex) {
 
 // ===[ Vtable ]===
 
-static AudioSystemVtable webAudioSystemVtable = {
-    .init = webInit,
-    .destroy = webDestroy,
-    .update = webUpdate,
-    .playSound = webPlaySound,
-    .stopSound = webStopSound,
-    .stopAll = webStopAll,
-    .isPlaying = webIsPlaying,
-    .pauseSound = webPauseSound,
-    .resumeSound = webResumeSound,
-    .pauseAll = webPauseAll,
-    .resumeAll = webResumeAll,
-    .setSoundGain = webSetSoundGain,
-    .getSoundGain = webGetSoundGain,
-    .setSoundPitch = webSetSoundPitch,
-    .getSoundPitch = webGetSoundPitch,
-    .getTrackPosition = webGetTrackPosition,
-    .setTrackPosition = webSetTrackPosition,
-    .getSoundLength = webGetSoundLength,
-    .setMasterGain = webSetMasterGain,
-    .setChannelCount = webSetChannelCount,
-    .groupLoad = webGroupLoad,
-    .groupIsLoaded = webGroupIsLoaded,
-    .createStream = webCreateStream,
-    .destroyStream = webDestroyStream,
-};
+static AudioSystemVtable webAudioSystemVtable;
 
 // ===[ Lifecycle ]===
 
 WebAudioSystem* WebAudioSystem_create(int32_t sampleRate) {
     WebAudioSystem* ma = safeCalloc(1, sizeof(WebAudioSystem));
+    webAudioSystemVtable.init = webInit;
+    webAudioSystemVtable.destroy = webDestroy;
+    webAudioSystemVtable.update = webUpdate;
+    webAudioSystemVtable.playSound = webPlaySound;
+    webAudioSystemVtable.stopSound = webStopSound;
+    webAudioSystemVtable.stopAll = webStopAll;
+    webAudioSystemVtable.isPlaying = webIsPlaying;
+    webAudioSystemVtable.pauseSound = webPauseSound;
+    webAudioSystemVtable.resumeSound = webResumeSound;
+    webAudioSystemVtable.pauseAll = webPauseAll;
+    webAudioSystemVtable.resumeAll = webResumeAll;
+    webAudioSystemVtable.setSoundGain = webSetSoundGain;
+    webAudioSystemVtable.getSoundGain = webGetSoundGain;
+    webAudioSystemVtable.setSoundPitch = webSetSoundPitch;
+    webAudioSystemVtable.getSoundPitch = webGetSoundPitch;
+    webAudioSystemVtable.getTrackPosition = webGetTrackPosition;
+    webAudioSystemVtable.setTrackPosition = webSetTrackPosition;
+    webAudioSystemVtable.getSoundLength = webGetSoundLength;
+    webAudioSystemVtable.setMasterGain = webSetMasterGain;
+    webAudioSystemVtable.setChannelCount = webSetChannelCount;
+    webAudioSystemVtable.groupLoad = webGroupLoad;
+    webAudioSystemVtable.groupIsLoaded = webGroupIsLoaded;
+    webAudioSystemVtable.createStream = webCreateStream;
+    webAudioSystemVtable.destroyStream = webDestroyStream;
     ma->base.vtable = &webAudioSystemVtable;
     ma->sampleRate = sampleRate > 0 ? sampleRate : 48000;
     return ma;

--- a/src/binary_reader.c
+++ b/src/binary_reader.c
@@ -6,7 +6,10 @@
 #include <string.h>
 
 BinaryReader BinaryReader_create(FILE* file, size_t fileSize) {
-    return (BinaryReader){.file = file, .fileSize = fileSize, .buffer = nullptr, .bufferBase = 0, .bufferSize = 0, .bufferPos = 0};
+    BinaryReader br = {0};
+    br.file = file;
+    br.fileSize = fileSize;
+    return br;
 }
 
 void BinaryReader_setBuffer(BinaryReader* reader, uint8_t* buffer, size_t baseOffset, size_t size) {

--- a/src/common.h
+++ b/src/common.h
@@ -5,6 +5,19 @@
 #define nullptr NULL
 #endif
 
+#ifndef UINT32_MAX
+#define UINT32_MAX 0xFFFFFFFFU
+#endif
+#ifndef INT32_MAX
+#define INT32_MAX 0x7FFFFFFF
+#endif
+#ifndef INT32_MIN
+#define INT32_MIN (-INT32_MAX - 1)
+#endif
+#ifndef INFINITY
+#define INFINITY (1.0f / 0.0f)
+#endif
+
 #if (defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)) || defined(__BIG_ENDIAN__)
 #define IS_BIG_ENDIAN
 #endif

--- a/src/data_win.c
+++ b/src/data_win.c
@@ -69,7 +69,10 @@ static InternalPathPoint* tempIntPoints = nullptr;
 static uint32_t tempIntPointCount = 0;
 
 static void addInternalPoint(float x, float y, float speed) {
-    InternalPathPoint pt = { .x = x, .y = y, .speed = speed, .l = 0.0 };
+    InternalPathPoint pt = {0};
+    pt.x = x;
+    pt.y = y;
+    pt.speed = speed;
     arrput(tempIntPoints, pt);
     tempIntPointCount++;
 }
@@ -170,7 +173,7 @@ void GamePath_computeInternal(GamePath* path) {
 
 // Get interpolated position at t in [0,1] (yyPath.js:362-409)
 PathPositionResult GamePath_getPosition(GamePath* path, float t) {
-    PathPositionResult result = { .x = 0.0f, .y = 0.0f, .speed = 0.0f };
+    PathPositionResult result = {0};
 
     if (path->internalPointCount == 0) return result;
 
@@ -593,7 +596,7 @@ static void parseSOND(BinaryReader* reader, DataWin* dw) {
         } else if (soundCount == 1) {
             size_t savedPos = BinaryReader_getPosition(reader);
             size_t probe = (size_t) (soundPtrs[0] + (4 * 9));
-            requireMessageFormatted((probe % 16) != 4, "parseSOND: unexpected SOND alignment at 0x%zx");
+            requireMessageFormatted(__FILE__, __LINE__, (probe % 16) != 4, "parseSOND: unexpected SOND alignment at 0x%zx");
             BinaryReader_seek(reader, probe);
             if (BinaryReader_readUint32(reader) != 0) {
                 DataWin_bumpVersionTo(dw, 2024, 6, 0, 0);

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -794,37 +794,34 @@ int main(int argc, char* argv[]) {
     while (true) {
         printf("Loading %s...\n", args.dataWinPath);
 
-        DataWin* dataWin = DataWin_parse(
-            currentDataWinPath,
-            (DataWinParserOptions) {
-                .parseGen8 = true,
-                .parseOptn = true,
-                .parseLang = true,
-                .parseExtn = true,
-                .parseSond = true,
-                .parseAgrp = true,
-                .parseSprt = true,
-                .parseBgnd = true,
-                .parsePath = true,
-                .parseScpt = true,
-                .parseGlob = true,
-                .parseShdr = true,
-                .parseFont = true,
-                .parseTmln = true,
-                .parseObjt = true,
-                .parseRoom = true,
-                .parseTpag = true,
-                .parseCode = true,
-                .parseVari = true,
-                .parseFunc = true,
-                .parseStrg = true,
-                .parseTxtr = true,
-                .parseAudo = true,
-                .skipLoadingPreciseMasksForNonPreciseSprites = true,
-                .lazyLoadRooms = args.lazyRooms,
-                .eagerlyLoadedRooms = args.eagerRooms
-            }
-        );
+        DataWinParserOptions options = {0};
+        options.parseGen8 = true;
+        options.parseOptn = true;
+        options.parseLang = true;
+        options.parseExtn = true;
+        options.parseSond = true;
+        options.parseAgrp = true;
+        options.parseSprt = true;
+        options.parseBgnd = true;
+        options.parsePath = true;
+        options.parseScpt = true;
+        options.parseGlob = true;
+        options.parseShdr = true;
+        options.parseFont = true;
+        options.parseTmln = true;
+        options.parseObjt = true;
+        options.parseRoom = true;
+        options.parseTpag = true;
+        options.parseCode = true;
+        options.parseVari = true;
+        options.parseFunc = true;
+        options.parseStrg = true;
+        options.parseTxtr = true;
+        options.parseAudo = true;
+        options.skipLoadingPreciseMasksForNonPreciseSprites = true;
+        options.lazyLoadRooms = args.lazyRooms;
+        options.eagerlyLoadedRooms = args.eagerRooms;
+        DataWin* dataWin = DataWin_parse(currentDataWinPath, options);
 
         Gen8* gen8 = &dataWin->gen8;
         printf("Loaded \"%s\" (%d) successfully! [WAD Version %u / GameMaker version %u.%u.%u.%u]\n", gen8->name, gen8->gameID, gen8->wadVersion, dataWin->detectedFormat.major, dataWin->detectedFormat.minor, dataWin->detectedFormat.release, dataWin->detectedFormat.build);
@@ -1192,7 +1189,8 @@ int main(int argc, char* argv[]) {
         runner->vmContext->traceEventInherited = args.traceEventInherited;
 
 #ifndef _WIN32
-        struct sigaction sa = { .sa_handler = onCrashSignal };
+        struct sigaction sa = {0};
+        sa.sa_handler = onCrashSignal;
         sigemptyset(&sa.sa_mask);
         struct sigaction prev;
         sigaction(SIGABRT, &sa, &prev);

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -1654,60 +1654,58 @@ static void glGpuSetFog(Renderer* renderer, bool enable, uint32_t color) {
 
 // ===[ Vtable ]===
 
-static RendererVtable glVtable = {
-    .init = glInit,
-    .destroy = glDestroy,
-    .beginFrame = glBeginFrame,
-    .endFrameInit = glEndFrameInit,
-    .endFrameEnd = glEndFrameEnd,
-    .beginView = glBeginView,
-    .endView = glEndView,
-    .applyProjection = glApplyProjection,
-    .beginGUI = glBeginGUI,
-    .endGUI = glEndGUI,
-    .drawSprite = glDrawSprite,
-    .drawSpritePos = glDrawSpritePos,
-    .drawSpritePart = glDrawSpritePart,
-    .drawRectangle = glDrawRectangle,
-    .drawRectangleColor = glDrawRectangleColor,
-    .drawLine = glDrawLine,
-    .drawLineColor = glDrawLineColor,
-    .drawTriangle = glDrawTriangle,
-    .drawText = glDrawText,
-    .drawTextColor = glDrawTextColor,
-    .flush = glRendererFlush,
-    .clearScreen = glClearScreen,
-    .createSpriteFromSurface = glCreateSpriteFromSurface,
-    .deleteSprite = glDeleteSprite,
-    .gpuSetBlendMode = glGpuSetBlendMode,
-    .gpuSetBlendModeExt = glGpuSetBlendModeExt,
-    .gpuSetBlendEnable = glGpuSetBlendEnable,
-    .gpuSetAlphaTestEnable = glGpuSetAlphaTestEnable,
-    .gpuSetAlphaTestRef = glGpuSetAlphaTestRef,
-    .gpuSetColorWriteEnable = glGpuSetColorWriteEnable,
-    .gpuGetColorWriteEnable = glGpuGetColorWriteEnable,
-    .gpuSetFog = glGpuSetFog,
-    .gpuGetBlendEnable = glGpuGetBlendEnable,
-    .drawTile = nullptr,
-    .createSurface = glCreateSurface,
-    .surfaceExists = glSurfaceExists,
-    .setRenderTarget = glSetRenderTarget,
-    .ensureApplicationSurface = glEnsureApplicationSurface,
-    .surfaceCopy = glSurfaceCopy,
-    .surfaceGetPixels = glSurfaceGetPixels,
-    .getSurfaceWidth = glGetSurfaceWidth,
-    .getSurfaceHeight = glGetSurfaceHeight,
-    .drawSurface = glDrawSurface,
-    .surfaceResize = glSurfaceResize,
-    .surfaceFree = glSurfaceFree,
-
-};
+static RendererVtable glVtable;
 
 // ===[ Public API ]===
 
 Renderer* GLRenderer_create(void) {
     GLRenderer* gl = safeCalloc(1, sizeof(GLRenderer));
     gl->base.vtable = &glVtable;
+    glVtable.init = glInit;
+    glVtable.destroy = glDestroy;
+    glVtable.beginFrame = glBeginFrame;
+    glVtable.endFrameInit = glEndFrameInit;
+    glVtable.endFrameEnd = glEndFrameEnd;
+    glVtable.beginView = glBeginView;
+    glVtable.endView = glEndView;
+    glVtable.applyProjection = glApplyProjection;
+    glVtable.beginGUI = glBeginGUI;
+    glVtable.endGUI = glEndGUI;
+    glVtable.drawSprite = glDrawSprite;
+    glVtable.drawSpritePos = glDrawSpritePos;
+    glVtable.drawSpritePart = glDrawSpritePart;
+    glVtable.drawRectangle = glDrawRectangle;
+    glVtable.drawRectangleColor = glDrawRectangleColor;
+    glVtable.drawLine = glDrawLine;
+    glVtable.drawLineColor = glDrawLineColor;
+    glVtable.drawTriangle = glDrawTriangle;
+    glVtable.drawText = glDrawText;
+    glVtable.drawTextColor = glDrawTextColor;
+    glVtable.flush = glRendererFlush;
+    glVtable.clearScreen = glClearScreen;
+    glVtable.createSpriteFromSurface = glCreateSpriteFromSurface;
+    glVtable.deleteSprite = glDeleteSprite;
+    glVtable.gpuSetBlendMode = glGpuSetBlendMode;
+    glVtable.gpuSetBlendModeExt = glGpuSetBlendModeExt;
+    glVtable.gpuSetBlendEnable = glGpuSetBlendEnable;
+    glVtable.gpuSetAlphaTestEnable = glGpuSetAlphaTestEnable;
+    glVtable.gpuSetAlphaTestRef = glGpuSetAlphaTestRef;
+    glVtable.gpuSetColorWriteEnable = glGpuSetColorWriteEnable;
+    glVtable.gpuGetColorWriteEnable = glGpuGetColorWriteEnable;
+    glVtable.gpuSetFog = glGpuSetFog;
+    glVtable.gpuGetBlendEnable = glGpuGetBlendEnable;
+    glVtable.drawTile = nullptr;
+    glVtable.createSurface = glCreateSurface;
+    glVtable.surfaceExists = glSurfaceExists;
+    glVtable.setRenderTarget = glSetRenderTarget;
+    glVtable.ensureApplicationSurface = glEnsureApplicationSurface;
+    glVtable.surfaceCopy = glSurfaceCopy;
+    glVtable.surfaceGetPixels = glSurfaceGetPixels;
+    glVtable.getSurfaceWidth = glGetSurfaceWidth;
+    glVtable.getSurfaceHeight = glGetSurfaceHeight;
+    glVtable.drawSurface = glDrawSurface;
+    glVtable.surfaceResize = glSurfaceResize;
+    glVtable.surfaceFree = glSurfaceFree;
     gl->base.drawColor = 0xFFFFFF; // white (BGR)
     gl->base.drawAlpha = 1.0f;
     gl->base.drawFont = -1;

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -1590,59 +1590,58 @@ static bool glLegacySurfaceGetPixels(Renderer* renderer, int32_t surfaceId, uint
 
 // ===[ Vtable ]===
 
-static RendererVtable glVtable = {
-    .init = glInit,
-    .destroy = glDestroy,
-    .beginFrame = glBeginFrame,
-    .endFrameInit = glEndFrameInit,
-    .endFrameEnd = glEndFrameEnd,
-    .beginView = glBeginView,
-    .endView = glEndView,
-    .applyProjection = glApplyProjection,
-    .beginGUI = glBeginGUI,
-    .endGUI = glEndGUI,
-    .drawSprite = glDrawSprite,
-    .drawSpritePos = glDrawSpritePos,
-    .drawSpritePart = glDrawSpritePart,
-    .drawRectangle = glDrawRectangle,
-    .drawRectangleColor = glDrawRectangleColor,
-    .drawLine = glDrawLine,
-    .drawLineColor = glDrawLineColor,
-    .drawTriangle = glDrawTriangle,
-    .drawText = glDrawText,
-    .drawTextColor = glDrawTextColor,
-    .flush = glRendererFlush,
-    .clearScreen = glClearScreen,
-    .createSpriteFromSurface = glCreateSpriteFromSurface,
-    .deleteSprite = glDeleteSprite,
-    .gpuSetBlendMode = glGpuSetBlendMode,
-    .gpuSetBlendModeExt = glGpuSetBlendModeExt,
-    .gpuSetBlendEnable = glGpuSetBlendEnable,
-    .gpuSetAlphaTestEnable = glGpuSetAlphaTestEnable,
-    .gpuSetAlphaTestRef = glGpuSetAlphaTestRef,
-    .gpuSetColorWriteEnable = glGpuSetColorWriteEnable,
-    .gpuGetColorWriteEnable = glGpuGetColorWriteEnable,
-    .gpuGetBlendEnable = glGpuGetBlendEnable,
-    .drawTile = nullptr,
-    .drawTiled = glDrawTiled,
-    .createSurface = glLegacyCreateSurface,
-    .surfaceExists = glLegacySurfaceExists,
-    .setRenderTarget = glLegacySetRenderTarget,
-    .ensureApplicationSurface = glLegacyEnsureApplicationSurface,
-    .getSurfaceWidth = glLegacyGetSurfaceWidth,
-    .getSurfaceHeight = glLegacyGetSurfaceHeight,
-    .drawSurface = glLegacyDrawSurface,
-    .surfaceResize = glLegacySurfaceResize,
-    .surfaceFree = glLegacySurfaceFree,
-    .surfaceCopy = glLegacySurfaceCopy,
-    .surfaceGetPixels = glLegacySurfaceGetPixels,
-};
+static RendererVtable glVtable;
 
 // ===[ Public API ]===
 
 Renderer* GLLegacyRenderer_create(void) {
     GLLegacyRenderer* gl = safeCalloc(1, sizeof(GLLegacyRenderer));
     gl->base.vtable = &glVtable;
+    glVtable.init = glInit;
+    glVtable.destroy = glDestroy;
+    glVtable.beginFrame = glBeginFrame;
+    glVtable.endFrameInit = glEndFrameInit;
+    glVtable.endFrameEnd = glEndFrameEnd;
+    glVtable.beginView = glBeginView;
+    glVtable.endView = glEndView;
+    glVtable.applyProjection = glApplyProjection;
+    glVtable.beginGUI = glBeginGUI;
+    glVtable.endGUI = glEndGUI;
+    glVtable.drawSprite = glDrawSprite;
+    glVtable.drawSpritePos = glDrawSpritePos;
+    glVtable.drawSpritePart = glDrawSpritePart;
+    glVtable.drawRectangle = glDrawRectangle;
+    glVtable.drawRectangleColor = glDrawRectangleColor;
+    glVtable.drawLine = glDrawLine;
+    glVtable.drawLineColor = glDrawLineColor;
+    glVtable.drawTriangle = glDrawTriangle;
+    glVtable.drawText = glDrawText;
+    glVtable.drawTextColor = glDrawTextColor;
+    glVtable.flush = glRendererFlush;
+    glVtable.clearScreen = glClearScreen;
+    glVtable.createSpriteFromSurface = glCreateSpriteFromSurface;
+    glVtable.deleteSprite = glDeleteSprite;
+    glVtable.gpuSetBlendMode = glGpuSetBlendMode;
+    glVtable.gpuSetBlendModeExt = glGpuSetBlendModeExt;
+    glVtable.gpuSetBlendEnable = glGpuSetBlendEnable;
+    glVtable.gpuSetAlphaTestEnable = glGpuSetAlphaTestEnable;
+    glVtable.gpuSetAlphaTestRef = glGpuSetAlphaTestRef;
+    glVtable.gpuSetColorWriteEnable = glGpuSetColorWriteEnable;
+    glVtable.gpuGetColorWriteEnable = glGpuGetColorWriteEnable;
+    glVtable.gpuGetBlendEnable = glGpuGetBlendEnable;
+    glVtable.drawTile = nullptr;
+    glVtable.drawTiled = glDrawTiled;
+    glVtable.createSurface = glLegacyCreateSurface;
+    glVtable.surfaceExists = glLegacySurfaceExists;
+    glVtable.setRenderTarget = glLegacySetRenderTarget;
+    glVtable.ensureApplicationSurface = glLegacyEnsureApplicationSurface;
+    glVtable.getSurfaceWidth = glLegacyGetSurfaceWidth;
+    glVtable.getSurfaceHeight = glLegacyGetSurfaceHeight;
+    glVtable.drawSurface = glLegacyDrawSurface;
+    glVtable.surfaceResize = glLegacySurfaceResize;
+    glVtable.surfaceFree = glLegacySurfaceFree;
+    glVtable.surfaceCopy = glLegacySurfaceCopy;
+    glVtable.surfaceGetPixels = glLegacySurfaceGetPixels;
     gl->base.drawColor = 0xFFFFFF; // white (BGR)
     gl->base.drawAlpha = 1.0f;
     gl->base.drawFont = -1;

--- a/src/gml_array.c
+++ b/src/gml_array.c
@@ -10,9 +10,7 @@ static void ensureRowCapacity(GMLArray* arr, int32_t minRows) {
     int32_t newCap = arr->rowCapacity > 0 ? arr->rowCapacity : 4;
     while (minRows > newCap) newCap *= 2;
     arr->rows = safeRealloc(arr->rows, (uint32_t) newCap * sizeof(GMLArrayRow));
-    for (int32_t i = arr->rowCapacity; newCap > i; i++) {
-        arr->rows[i] = (GMLArrayRow){ .length = 0, .capacity = 0, .data = nullptr };
-    }
+    memset(arr->rows + arr->rowCapacity, 0, (newCap - arr->rowCapacity) * sizeof(GMLArrayRow));
     arr->rowCapacity = newCap;
 }
 

--- a/src/ini.c
+++ b/src/ini.c
@@ -10,7 +10,7 @@
 // ===[ Internal Helpers ]===
 
 static IniSection* findSection(const IniFile* ini, const char* name) {
-    repeat(ini->count, i) {
+    for (int i = 0; i < ini->count; ++i) {
         if (strcmp(ini->sections[i].name, name) == 0) {
             return &ini->sections[i];
         }
@@ -19,7 +19,7 @@ static IniSection* findSection(const IniFile* ini, const char* name) {
 }
 
 static int findKeyIndex(const IniSection* section, const char* key) {
-    repeat(section->count, i) {
+    for (int i = 0; i < section->count; ++i) {
         if (strcmp(section->keys[i], key) == 0) {
             return i;
         }
@@ -270,7 +270,7 @@ char* Ini_serialize(const IniFile* ini, size_t initialCapacity) {
     char* buffer = safeMalloc(capacity);
     buffer[0] = '\0';
 
-    repeat(ini->count, i) {
+    for (int i = 0; i < ini->count; ++i) {
         IniSection* section = &ini->sections[i];
 
         // Blank line before section (unless at start of output)

--- a/src/json_reader.c
+++ b/src/json_reader.c
@@ -357,11 +357,10 @@ JsonValue* JsonReader_parse(const char* json) {
         pos = 3;
     }
 
-    JsonParser parser = {
-        .input = json,
-        .position = pos,
-        .length = len,
-    };
+    JsonParser parser = {0};
+    parser.input = json;
+    parser.position = pos;
+    parser.length = len;
 
     JsonValue* result = parseValue(&parser);
 
@@ -490,7 +489,7 @@ int JsonReader_objectLength(const JsonValue* value) {
 }
 
 JsonValue* JsonReader_getObject(const JsonValue* value, const char* key) {
-    repeat(value->object.count, i) {
+    for (int i = 0; i < value->object.count; ++i) {
         if (strcmp(value->object.keys[i], key) == 0) {
             return &value->object.values[i];
         }

--- a/src/json_writer.c
+++ b/src/json_writer.c
@@ -40,10 +40,10 @@ static void writeEscapedString(JsonWriter* writer, const char* str) {
 // ===[ Lifecycle ]===
 
 JsonWriter JsonWriter_create(void) {
-    return (JsonWriter) {
-        .out = StringBuilder_create(256),
-        .needsComma = false,
-    };
+    JsonWriter ret = {0};
+    ret.out = StringBuilder_create(256);
+    ret.needsComma = false;
+    return ret;
 }
 
 void JsonWriter_free(JsonWriter* writer) {

--- a/src/noop_audio_system.c
+++ b/src/noop_audio_system.c
@@ -71,35 +71,34 @@ static bool noopDestroyStream(MAYBE_UNUSED AudioSystem* audio, MAYBE_UNUSED int3
     return false;
 }
 
-static AudioSystemVtable noopVtable = {
-    .init = noopInit,
-    .destroy = noopDestroy,
-    .update = noopUpdate,
-    .playSound = noopPlaySound,
-    .stopSound = noopStopSound,
-    .stopAll = noopStopAll,
-    .isPlaying = noopIsPlaying,
-    .pauseSound = noopPauseSound,
-    .resumeSound = noopResumeSound,
-    .pauseAll = noopPauseAll,
-    .resumeAll = noopResumeAll,
-    .setSoundGain = noopSetSoundGain,
-    .getSoundGain = noopGetSoundGain,
-    .setSoundPitch = noopSetSoundPitch,
-    .getSoundPitch = noopGetSoundPitch,
-    .getTrackPosition = noopGetTrackPosition,
-    .setTrackPosition = noopSetTrackPosition,
-    .getSoundLength = noopGetSoundLength,
-    .setMasterGain = noopSetMasterGain,
-    .setChannelCount = noopSetChannelCount,
-    .groupLoad = noopGroupLoad,
-    .groupIsLoaded = noopGroupIsLoaded,
-    .createStream = noopCreateStream,
-    .destroyStream = noopDestroyStream,
-};
+static AudioSystemVtable noopVtable;
 
 NoopAudioSystem* NoopAudioSystem_create(void) {
-    NoopAudioSystem* audio = calloc(1, sizeof(NoopAudioSystem));
+    NoopAudioSystem* audio = safeCalloc(1, sizeof(NoopAudioSystem));
+    noopVtable.init = noopInit,
+    noopVtable.destroy = noopDestroy,
+    noopVtable.update = noopUpdate,
+    noopVtable.playSound = noopPlaySound,
+    noopVtable.stopSound = noopStopSound,
+    noopVtable.stopAll = noopStopAll,
+    noopVtable.isPlaying = noopIsPlaying,
+    noopVtable.pauseSound = noopPauseSound,
+    noopVtable.resumeSound = noopResumeSound,
+    noopVtable.pauseAll = noopPauseAll,
+    noopVtable.resumeAll = noopResumeAll,
+    noopVtable.setSoundGain = noopSetSoundGain,
+    noopVtable.getSoundGain = noopGetSoundGain,
+    noopVtable.setSoundPitch = noopSetSoundPitch,
+    noopVtable.getSoundPitch = noopGetSoundPitch,
+    noopVtable.getTrackPosition = noopGetTrackPosition,
+    noopVtable.setTrackPosition = noopSetTrackPosition,
+    noopVtable.getSoundLength = noopGetSoundLength,
+    noopVtable.setMasterGain = noopSetMasterGain,
+    noopVtable.setChannelCount = noopSetChannelCount,
+    noopVtable.groupLoad = noopGroupLoad,
+    noopVtable.groupIsLoaded = noopGroupIsLoaded,
+    noopVtable.createStream = noopCreateStream,
+    noopVtable.destroyStream = noopDestroyStream,
     audio->base.vtable = &noopVtable;
     return audio;
 }

--- a/src/noop_file_system.c
+++ b/src/noop_file_system.c
@@ -107,7 +107,9 @@ static bool noopWriteFileBinary(FileSystem* fs, const char* relativePath, const 
     } else {
         uint8_t* copy = safeMalloc((size_t) size);
         memcpy(copy, data, (size_t) size);
-        MemoryBinaryData binaryData = { .data = copy, .size = size };
+        MemoryBinaryData binaryData = {0};
+        binaryData.data = copy;
+        binaryData.size = size;
         shput(nfs->binaryFiles, relativePath, binaryData);
     }
 
@@ -165,7 +167,9 @@ static void noopBinaryClose(MAYBE_UNUSED FileSystem* fs, void* handle) {
             h->owner->binaryFiles[idx].value.data = h->buffer;
             h->owner->binaryFiles[idx].value.size = h->size;
         } else {
-            MemoryBinaryData data = { .data = h->buffer, .size = h->size };
+            MemoryBinaryData data = {0};
+            data.data = h->buffer;
+            data.size = h->size;
             shput(h->owner->binaryFiles, h->path, data);
         }
         // Map now owns the buffer
@@ -294,13 +298,28 @@ static FileSystemDirEntry* noopListDirectory(FileSystem* fs, const char* relativ
     FileSystemDirEntry* entries = nullptr;
     const char* base;
     repeat(shlen(nfs->files), i) {
-        if (keyInDir(nfs->files[i].key, dir, &base)) arrput(entries, ((FileSystemDirEntry) { .name = safeStrdup(base), .isDirectory = false }));
+        if (keyInDir(nfs->files[i].key, dir, &base)) {
+            FileSystemDirEntry e = {0};
+            e.name = safeStrdup(base);
+            e.isDirectory = false;
+            arrput(entries, e);
+        }
     }
     repeat(shlen(nfs->binaryFiles), i) {
-        if (keyInDir(nfs->binaryFiles[i].key, dir, &base)) arrput(entries, ((FileSystemDirEntry) { .name = safeStrdup(base), .isDirectory = false }));
+        if (keyInDir(nfs->binaryFiles[i].key, dir, &base)) {
+            FileSystemDirEntry e = {0};
+            e.name = safeStrdup(base);
+            e.isDirectory = false;
+            arrput(entries, e);
+        }
     }
     repeat(shlen(nfs->directories), i) {
-        if (keyInDir(nfs->directories[i].key, dir, &base)) arrput(entries, ((FileSystemDirEntry) { .name = safeStrdup(base), .isDirectory = true }));
+        if (keyInDir(nfs->directories[i].key, dir, &base)) {
+            FileSystemDirEntry e = {0};
+            e.name = safeStrdup(base);
+            e.isDirectory = true;
+            arrput(entries, e);
+        }
     }
 
     free(dir);
@@ -309,33 +328,32 @@ static FileSystemDirEntry* noopListDirectory(FileSystem* fs, const char* relativ
 
 // ===[ Vtable ]===
 
-static FileSystemVtable noopFileSystemVtable = {
-    .resolvePath = noopResolvePath,
-    .fileExists = noopFileExists,
-    .readFileText = noopReadFileText,
-    .writeFileText = noopWriteFileText,
-    .deleteFile = noopDeleteFile,
-    .readFileBinary = noopReadFileBinary,
-    .writeFileBinary = noopWriteFileBinary,
-    .binaryOpen = noopBinaryOpen,
-    .binaryClose = noopBinaryClose,
-    .binaryRead = noopBinaryRead,
-    .binaryWrite = noopBinaryWrite,
-    .binaryTell = noopBinaryTell,
-    .binarySeek = noopBinarySeek,
-    .binarySize = noopBinarySize,
-    .binaryRewrite = noopBinaryRewrite,
-    .directoryExists = noopDirectoryExists,
-    .createDirectory = noopCreateDirectory,
-    .deleteDirectory = noopDeleteDirectory,
-    .listDirectory = noopListDirectory,
-};
+static FileSystemVtable noopFileSystemVtable;
 
 // ===[ Lifecycle ]===
 
 FileSystem* NoopFileSystem_create(void) {
     NoopFileSystem* nfs = safeCalloc(1, sizeof(NoopFileSystem));
     nfs->base.vtable = &noopFileSystemVtable;
+    noopFileSystemVtable.resolvePath = noopResolvePath;
+    noopFileSystemVtable.fileExists = noopFileExists;
+    noopFileSystemVtable.readFileText = noopReadFileText;
+    noopFileSystemVtable.writeFileText = noopWriteFileText;
+    noopFileSystemVtable.deleteFile = noopDeleteFile;
+    noopFileSystemVtable.readFileBinary = noopReadFileBinary;
+    noopFileSystemVtable.writeFileBinary = noopWriteFileBinary;
+    noopFileSystemVtable.binaryOpen = noopBinaryOpen;
+    noopFileSystemVtable.binaryClose = noopBinaryClose;
+    noopFileSystemVtable.binaryRead = noopBinaryRead;
+    noopFileSystemVtable.binaryWrite = noopBinaryWrite;
+    noopFileSystemVtable.binaryTell = noopBinaryTell;
+    noopFileSystemVtable.binarySeek = noopBinarySeek;
+    noopFileSystemVtable.binarySize = noopBinarySize;
+    noopFileSystemVtable.binaryRewrite = noopBinaryRewrite;
+    noopFileSystemVtable.directoryExists = noopDirectoryExists;
+    noopFileSystemVtable.createDirectory = noopCreateDirectory;
+    noopFileSystemVtable.deleteDirectory = noopDeleteDirectory;
+    noopFileSystemVtable.listDirectory = noopListDirectory;
     nfs->files = nullptr;
     sh_new_strdup(nfs->files);
     nfs->binaryFiles = nullptr;

--- a/src/overlay_file_system.c
+++ b/src/overlay_file_system.c
@@ -324,7 +324,9 @@ static void dirListPush(FileSystemDirEntry** list, const char* name, bool isDire
     repeat(arrlen(*list), i) {
         if (strcmp((*list)[i].name, name) == 0) return;
     }
-    FileSystemDirEntry entry = { .name = safeStrdup(name), .isDirectory = isDirectory };
+    FileSystemDirEntry entry = {0};
+    entry.name = safeStrdup(name);
+    entry.isDirectory = isDirectory;
     arrput(*list, entry);
 }
 
@@ -394,25 +396,6 @@ static FileSystemDirEntry* overlayListDirectory(FileSystem* fs, const char* rela
 // ===[ Vtable ]===
 
 static FileSystemVtable overlayFileSystemVtable = {
-    .resolvePath = overlayResolvePath,
-    .fileExists = overlayFileExists,
-    .readFileText = overlayReadFileText,
-    .writeFileText = overlayWriteFileText,
-    .deleteFile = overlayDeleteFile,
-    .readFileBinary = overlayReadFileBinary,
-    .writeFileBinary = overlayWriteFileBinary,
-    .binaryOpen = overlayBinaryOpen,
-    .binaryClose = overlayBinaryClose,
-    .binaryRead = overlayBinaryRead,
-    .binaryWrite = overlayBinaryWrite,
-    .binaryTell = overlayBinaryTell,
-    .binarySeek = overlayBinarySeek,
-    .binarySize = overlayBinarySize,
-    .binaryRewrite = overlayBinaryRewrite,
-    .directoryExists = overlayDirectoryExists,
-    .createDirectory = overlayCreateDirectory,
-    .deleteDirectory = overlayDeleteDirectory,
-    .listDirectory = overlayListDirectory,
 };
 
 // ===[ Lifecycle ]===
@@ -437,6 +420,25 @@ static char* withTrailingSlash(const char* path) {
 OverlayFileSystem* OverlayFileSystem_create(const char* bundlePath, const char* savePath) {
     OverlayFileSystem* fs = safeCalloc(1, sizeof(OverlayFileSystem));
     fs->base.vtable = &overlayFileSystemVtable;
+    overlayFileSystemVtable.resolvePath = overlayResolvePath;
+    overlayFileSystemVtable.fileExists = overlayFileExists;
+    overlayFileSystemVtable.readFileText = overlayReadFileText;
+    overlayFileSystemVtable.writeFileText = overlayWriteFileText;
+    overlayFileSystemVtable.deleteFile = overlayDeleteFile;
+    overlayFileSystemVtable.readFileBinary = overlayReadFileBinary;
+    overlayFileSystemVtable.writeFileBinary = overlayWriteFileBinary;
+    overlayFileSystemVtable.binaryOpen = overlayBinaryOpen;
+    overlayFileSystemVtable.binaryClose = overlayBinaryClose;
+    overlayFileSystemVtable.binaryRead = overlayBinaryRead;
+    overlayFileSystemVtable.binaryWrite = overlayBinaryWrite;
+    overlayFileSystemVtable.binaryTell = overlayBinaryTell;
+    overlayFileSystemVtable.binarySeek = overlayBinarySeek;
+    overlayFileSystemVtable.binarySize = overlayBinarySize;
+    overlayFileSystemVtable.binaryRewrite = overlayBinaryRewrite;
+    overlayFileSystemVtable.directoryExists = overlayDirectoryExists;
+    overlayFileSystemVtable.createDirectory = overlayCreateDirectory;
+    overlayFileSystemVtable.deleteDirectory = overlayDeleteDirectory;
+    overlayFileSystemVtable.listDirectory = overlayListDirectory;
     fs->bundlePath = withTrailingSlash(bundlePath);
     fs->savePath = withTrailingSlash(savePath);
     return fs;

--- a/src/profiler.c
+++ b/src/profiler.c
@@ -106,7 +106,9 @@ void Profiler_exit(Profiler* p) {
 
     ptrdiff_t i = shgeti(p->entries, f->name);
     if (0 > i) {
-        ProfilerStats stats = { .nanos = selfNanos, .ops = selfOps };
+        ProfilerStats stats = {0};
+        stats.nanos = selfNanos;
+        stats.ops = selfOps;
         shput(p->entries, f->name, stats);
     } else {
         p->entries[i].value.nanos += selfNanos;

--- a/src/ps2/main.c
+++ b/src/ps2/main.c
@@ -400,39 +400,37 @@ int main(int argc, char* argv[]) {
     // ===[ Parse data.win ]===
     PS2Overlay_drawStatusScreen(nullptr, "Loading data.win...", false);
 
-    DataWin* dataWin = DataWin_parse(
-        dataWinPath,
-        (DataWinParserOptions) {
-            .parseGen8 = true,
-            .parseOptn = true,
-            .parseLang = true,
-            .parseExtn = true,
-            .parseSond = true,
-            .parseAgrp = true,
-            .parseSprt = true,
-            .parseBgnd = true,
-            .parsePath = true,
-            .parseScpt = true,
-            .parseGlob = true,
-            .parseShdr = true,
-            .parseFont = true,
-            .parseTmln = true,
-            .parseObjt = true,
-            .parseRoom = true,
-            .parseTpag = true,
-            .parseCode = true,
-            .parseVari = true,
-            .parseFunc = true,
-            .parseStrg = true,
-            .parseTxtr = false,
-            .parseAudo = false,
-            .skipLoadingPreciseMasksForNonPreciseSprites = true,
-            .lazyLoadRooms = lazyLoadRooms,
-            .eagerlyLoadedRooms = eagerRooms,
-            .progressCallback = PS2Overlay_statusScreenCallback,
-            .progressCallbackUserData = PS2Overlay_getCallbackData(),
-        }
-    );
+    DataWinParserOptions options = {0};
+    options.parseGen8 = true;
+    options.parseOptn = true;
+    options.parseLang = true;
+    options.parseExtn = true;
+    options.parseSond = true;
+    options.parseAgrp = true;
+    options.parseSprt = true;
+    options.parseBgnd = true;
+    options.parsePath = true;
+    options.parseScpt = true;
+    options.parseGlob = true;
+    options.parseShdr = true;
+    options.parseFont = true;
+    options.parseTmln = true;
+    options.parseObjt = true;
+    options.parseRoom = true;
+    options.parseTpag = true;
+    options.parseCode = true;
+    options.parseVari = true;
+    options.parseFunc = true;
+    options.parseStrg = true;
+    options.parseTxtr = false;
+    options.parseAudo = false;
+    options.skipLoadingPreciseMasksForNonPreciseSprites = true;
+    options.lazyLoadRooms = lazyLoadRooms;
+    options.eagerlyLoadedRooms = eagerRooms;
+    options.progressCallback = PS2Overlay_statusScreenCallback;
+    options.progressCallbackUserData = PS2Overlay_getCallbackData();
+    
+    DataWin* dataWin = DataWin_parse(dataWinPath, options);
     free(dataWinPath);
     shfree(eagerRooms);
 

--- a/src/ps2/ps2_overlay.c
+++ b/src/ps2/ps2_overlay.c
@@ -251,7 +251,7 @@ void PS2Overlay_drawDebugOverlay(const Renderer* renderer, const Runner* runner,
     AtlasSizeBucket sizeBuckets[8] = { 0 };
     uint32_t sizeBucketCount = 0;
 
-    repeat(gsRenderer->atlasCount, ai) {
+    for (uint16_t ai = 0; ai < gsRenderer->atlasCount; ++ai) {
         bool resident = gsRenderer->atlasToChunk[ai] >= 0;
         if (resident) vramAtlasCount++;
         if (gsRenderer->eeCacheEntries[ai].atlasId >= 0) eeramAtlasCount++;
@@ -316,7 +316,7 @@ void PS2Overlay_drawDebugOverlay(const Renderer* renderer, const Runner* runner,
     }
 
     int pinned = 0;
-    repeat(gsRenderer->chunkCount, i) {
+    for (uint32_t i = 0; i < gsRenderer->chunkCount; ++i) {
         if (gsRenderer->chunks[i].snapshotIdx != -1 || gsRenderer->chunks[i].surfaceIdx != -1)
             pinned++;
     }

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -58,7 +58,7 @@ const PadMapping PAD_MAPPINGS[] = {
     { PAD_BUTTON_OFFSET_DIGITAL2, PAD_CTRL_R1,       VK_PAGEUP },
     { PAD_BUTTON_OFFSET_DIGITAL2, PAD_CTRL_L2,       VK_F10 },
 };
-static const int PAD_MAPPING_COUNT = sizeof(PAD_MAPPINGS) / sizeof(PAD_MAPPINGS[0]);
+#define PAD_MAPPING_COUNT = (sizeof(PAD_MAPPINGS) / sizeof(PAD_MAPPINGS[0]))
 static bool prevState[sizeof(PAD_MAPPINGS) / sizeof(PAD_MAPPINGS[0])] = {0};
 
 #define STICK_CENTER 0x80 // The center of the stick (range 0x00-0xFF)

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -76,7 +76,7 @@ const StickMapping STICK_MAPPINGS[] = {
     { PAD_BUTTON_OFFSET_ANALOG_LEFT_Y, -1, VK_UP    },
     { PAD_BUTTON_OFFSET_ANALOG_LEFT_Y, +1, VK_DOWN  },
 };
-static const int STICK_MAPPING_COUNT = sizeof(STICK_MAPPINGS) / sizeof(STICK_MAPPINGS[0]);
+#define STICK_MAPPING_COUNT (sizeof(STICK_MAPPINGS) / sizeof(STICK_MAPPINGS[0]))
 static bool prevStickState[sizeof(STICK_MAPPINGS) / sizeof(STICK_MAPPINGS[0])] = {0};
 
 // ===[ MAIN ]===

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -58,7 +58,7 @@ const PadMapping PAD_MAPPINGS[] = {
     { PAD_BUTTON_OFFSET_DIGITAL2, PAD_CTRL_R1,       VK_PAGEUP },
     { PAD_BUTTON_OFFSET_DIGITAL2, PAD_CTRL_L2,       VK_F10 },
 };
-#define PAD_MAPPING_COUNT = (sizeof(PAD_MAPPINGS) / sizeof(PAD_MAPPINGS[0]))
+#define PAD_MAPPING_COUNT (sizeof(PAD_MAPPINGS) / sizeof(PAD_MAPPINGS[0]))
 static bool prevState[sizeof(PAD_MAPPINGS) / sizeof(PAD_MAPPINGS[0])] = {0};
 
 #define STICK_CENTER 0x80 // The center of the stick (range 0x00-0xFF)

--- a/src/ps3/main.c
+++ b/src/ps3/main.c
@@ -174,38 +174,36 @@ int main(int argc, char* argv[]) {
 
     printf("Loading %s...\n", dataWinPath);
 
-    DataWin* dataWin = DataWin_parse(
-        dataWinPath,
-        (DataWinParserOptions) {
-            .parseGen8 = true,
-            .parseOptn = true,
-            .parseLang = true,
-            .parseExtn = true,
-            .parseSond = true,
-            .parseAgrp = true,
-            .parseSprt = true,
-            .parseBgnd = true,
-            .parsePath = true,
-            .parseScpt = true,
-            .parseGlob = true,
-            .parseShdr = true,
-            .parseFont = true,
-            .parseTmln = true,
-            .parseObjt = true,
-            .parseRoom = true,
-            .parseTpag = true,
-            .parseCode = true,
-            .parseVari = true,
-            .parseFunc = true,
-            .parseStrg = true,
-            // TXTR pages live in TEXTURES.BIN on PS3, not in data.win.
-            .parseTxtr = false,
-            .parseAudo = true,
-            .skipLoadingPreciseMasksForNonPreciseSprites = true,
-            .lazyLoadRooms = true,
-            //.eagerlyLoadedRooms = args.eagerRooms
-        }
-    );
+    DataWinParserOptions options = {0};
+    options.parseGen8 = true;
+    options.parseOptn = true;
+    options.parseLang = true;
+    options.parseExtn = true;
+    options.parseSond = true;
+    options.parseAgrp = true;
+    options.parseSprt = true;
+    options.parseBgnd = true;
+    options.parsePath = true;
+    options.parseScpt = true;
+    options.parseGlob = true;
+    options.parseShdr = true;
+    options.parseFont = true;
+    options.parseTmln = true;
+    options.parseObjt = true;
+    options.parseRoom = true;
+    options.parseTpag = true;
+    options.parseCode = true;
+    options.parseVari = true;
+    options.parseFunc = true;
+    options.parseStrg = true;
+    // TXTR pages live in TEXTURES.BIN on PS3, not in data.win.
+    options.parseTxtr = false;
+    options.parseAudo = true;
+    options.skipLoadingPreciseMasksForNonPreciseSprites = true;
+    options.lazyLoadRooms = true;
+    //options.eagerlyLoadedRooms = args.eagerRooms;
+
+    DataWin* dataWin = DataWin_parse(dataWinPath, options);
 
     Gen8* gen8 = &dataWin->gen8;
     printf("Loaded \"%s\" (%d) successfully! [WAD Version %u / GameMaker version %u.%u.%u.%u]\n", gen8->name, gen8->gameID, gen8->wadVersion, dataWin->detectedFormat.major, dataWin->detectedFormat.minor, dataWin->detectedFormat.release, dataWin->detectedFormat.build);

--- a/src/runner.c
+++ b/src/runner.c
@@ -648,7 +648,9 @@ static void rebuildDrawableCacheIfDirty(Runner* runner) {
         int32_t instanceCount = (int32_t) arrlen(runner->instances);
         repeat(instanceCount, i) {
             Instance* inst = runner->instances[i];
-            Drawable d = { .type = DRAWABLE_INSTANCE, .depth = inst->depth };
+            Drawable d = {0};
+            d.type = DRAWABLE_INSTANCE;
+            d.depth = inst->depth;
             d.instance = inst;
             arrput(runner->cachedDrawables, d);
         }
@@ -656,7 +658,9 @@ static void rebuildDrawableCacheIfDirty(Runner* runner) {
         if (!DataWin_isVersionAtLeast(runner->dataWin, 2, 0, 0, 0)) {
             repeat(room->tileCount, i) {
                 RoomTile* tile = &room->tiles[i];
-                Drawable d = { .type = DRAWABLE_TILE, .depth = tile->tileDepth };
+                Drawable d = {0};
+                d.type = DRAWABLE_TILE;
+                d.depth = tile->tileDepth;
                 d.tileIndex = (int32_t) i;
                 arrput(runner->cachedDrawables, d);
             }
@@ -664,7 +668,9 @@ static void rebuildDrawableCacheIfDirty(Runner* runner) {
             size_t runtimeLayersCount = arrlenu(runner->runtimeLayers);
             repeat(runtimeLayersCount, i) {
                 RuntimeLayer* runtimeLayer = &runner->runtimeLayers[i];
-                Drawable d = { .type = DRAWABLE_LAYER, .depth = runtimeLayer->depth };
+                Drawable d = {0};
+                d.type = DRAWABLE_LAYER;
+                d.depth = runtimeLayer->depth;
                 d.runtimeLayerId = (int32_t) runtimeLayer->id;
                 arrput(runner->cachedDrawables, d);
             }
@@ -1276,18 +1282,15 @@ static void initRoom(Runner* runner, int32_t roomIndex) {
     uint32_t maxLayerId = 0;
     repeat(room->layerCount, i) {
         RoomLayer* layerSource = &room->layers[i];
-        RuntimeLayer runtimeLayer = {
-            .id = layerSource->id,
-            .depth = layerSource->depth,
-            .visible = layerSource->visible,
-            .xOffset = layerSource->xOffset,
-            .yOffset = layerSource->yOffset,
-            .hSpeed = layerSource->hSpeed,
-            .vSpeed = layerSource->vSpeed,
-            .dynamic = false,
-            .dynamicName = nullptr,
-            .elements = nullptr,
-        };
+        RuntimeLayer runtimeLayer = {0};
+        runtimeLayer.id = layerSource->id;
+        runtimeLayer.depth = layerSource->depth;
+        runtimeLayer.visible = layerSource->visible;
+        runtimeLayer.xOffset = layerSource->xOffset;
+        runtimeLayer.yOffset = layerSource->yOffset;
+        runtimeLayer.hSpeed = layerSource->hSpeed;
+        runtimeLayer.vSpeed = layerSource->vSpeed;
+        runtimeLayer.dynamic = false;
         arrput(runner->runtimeLayers, runtimeLayer);
         if (layerSource->id > maxLayerId) maxLayerId = layerSource->id;
     }
@@ -1313,29 +1316,25 @@ static void initRoom(Runner* runner, int32_t roomIndex) {
             spriteElement->animationSpeedType = src->animationSpeedType;
             spriteElement->frameIndex = src->frameIndex;
             spriteElement->rotation = src->rotation;
-            RuntimeLayerElement el = {
-                .id = Runner_getNextLayerId(runner),
-                .type = RuntimeLayerElementType_Sprite,
-                .visible = true,
-                .alpha = 1.0f,
-                .backgroundElement = nullptr,
-                .spriteElement = spriteElement,
-                .tileElement = nullptr,
-            };
+            RuntimeLayerElement el = {0};
+            el.id = Runner_getNextLayerId(runner);
+            el.type = RuntimeLayerElementType_Sprite;
+            el.visible = true;
+            el.alpha = 1.0f;
+            el.spriteElement = spriteElement;
             arrput(runtimeLayer->elements, el);
         }
         // Expose legacy tiles as RuntimeLayerElements so GML scripts can find them via layer_get_all_elements and toggle them via layer_tile_visible
         repeat(assets->legacyTileCount, j) {
             RoomTile* tile = &assets->legacyTiles[j];
-            RuntimeLayerElement el = {
-                .id = Runner_getNextLayerId(runner),
-                .type = RuntimeLayerElementType_Tile,
-                .visible = true,
-                .alpha = tile->alpha,
-                .backgroundElement = nullptr,
-                .spriteElement = nullptr,
-                .tileElement = tile,
-            };
+            RuntimeLayerElement el = {0};
+            el.id = Runner_getNextLayerId(runner);
+            el.type = RuntimeLayerElementType_Tile;
+            el.visible = true;
+            el.alpha = tile->alpha;
+            el.backgroundElement = nullptr;
+            el.spriteElement = nullptr;
+            el.tileElement = tile;
             arrput(runtimeLayer->elements, el);
         }
     }
@@ -1679,7 +1678,11 @@ static void flattenCollisionEvents(Runner* runner) {
             repeat(src->eventCount, e) {
                 ObjectEvent* srcEvt = &src->events[e];
                 int32_t srcCodeId = (srcEvt->actionCount > 0) ? srcEvt->actions[0].codeId : -1;
-                dst->events[e] = (FlattenedCollisionEvent) { .targetObjectIndex = srcEvt->eventSubtype, .codeId = srcCodeId, .ownerObjectIndex = i };
+                FlattenedCollisionEvent fce = {0};
+                fce.targetObjectIndex = srcEvt->eventSubtype;
+                fce.codeId = srcCodeId;
+                fce.ownerObjectIndex = i;
+                dst->events[e] = fce;
             }
             dst->eventCount = src->eventCount;
         }
@@ -1702,7 +1705,11 @@ static void flattenCollisionEvents(Runner* runner) {
                 int32_t ancCodeId = (ancEvt->actionCount > 0) ? ancEvt->actions[0].codeId : -1;
                 uint32_t newCount = dst->eventCount + 1;
                 dst->events = safeRealloc(dst->events, newCount * sizeof(FlattenedCollisionEvent));
-                dst->events[newCount - 1] = (FlattenedCollisionEvent) { .targetObjectIndex = target, .codeId = ancCodeId, .ownerObjectIndex = ancestor };
+                FlattenedCollisionEvent fce = {0};
+                fce.targetObjectIndex = target;
+                fce.codeId = ancCodeId;
+                fce.ownerObjectIndex = ancestor;
+                dst->events[newCount - 1] = fce;
                 dst->eventCount = newCount;
             }
             ancestor = anc->parentId;
@@ -3104,7 +3111,7 @@ static void tickTimelines(Runner* runner) {
 
 void Runner_step(Runner* runner) {
     // The snapshot arena is stack-like and every push must be matched with a pop within the same frame. Assert that invariant at the top of each step: a non-zero length here means some site below pushed without popping, and we want a loud failure with the offending length so we can find it instead of silently leaking until the next frame.
-    requireMessageFormatted(arrlen(runner->instanceSnapshots) == 0, "instanceSnapshots arena was not fully popped at end of previous frame (length=%td)", arrlen(runner->instanceSnapshots));
+    requireMessageFormatted(__FILE__, __LINE__, arrlen(runner->instanceSnapshots) == 0, "instanceSnapshots arena was not fully popped at end of previous frame (length=%td)", arrlen(runner->instanceSnapshots));
 
     // Save xprevious/yprevious and path_positionprevious for all active instances
     int32_t prevCount = (int32_t) arrlen(runner->instances);

--- a/src/rvalue.h
+++ b/src/rvalue.h
@@ -91,69 +91,93 @@ struct RValue {
 } __attribute__((aligned(8)));
 
 static inline RValue RValue_makeReal(GMLReal val) {
-    RValue rv = { .type = RVALUE_REAL, .gmlStackType = GML_TYPE_DOUBLE };
+    RValue rv = {0};
+    rv.type = RVALUE_REAL;
+    rv.gmlStackType = GML_TYPE_DOUBLE;
     rv.real = val;
     return rv;
 }
 
 static inline RValue RValue_makeInt32(int32_t val) {
-    RValue rv = { .type = RVALUE_INT32, .gmlStackType = GML_TYPE_INT32 };
+    RValue rv = {0};
+    rv.type = RVALUE_INT32;
+    rv.gmlStackType = GML_TYPE_INT32;
     rv.int32 = val;
     return rv;
 }
 
 static inline RValue RValue_makeInt64(int64_t val) {
-    RValue rv;
+    RValue rv = {0};
 #ifdef NO_RVALUE_INT64
     // Values that don't fit in int32 get promoted to real instead of clamped, because clamping to INT32_MIN causes arithmetic overflow bugs
     // (example: Undertale's mercymod = -99999999999999 in the Asriel fight)
     if (val > INT32_MAX || INT32_MIN > val) {
-        rv = (RValue){ .type = RVALUE_REAL, .gmlStackType = GML_TYPE_DOUBLE };
+        rv.type = RVALUE_REAL;
+        rv.gmlStackType = GML_TYPE_DOUBLE;
         rv.real = val;
     } else {
-        rv = (RValue){ .type = RVALUE_INT32, .gmlStackType = GML_TYPE_INT32 };
+        rv.type = RVALUE_INT32;
+        rv.gmlStackType = GML_TYPE_INT32;
         rv.int32 = val;
     }
 #else
-    rv = (RValue){ .type = RVALUE_INT64, .gmlStackType = GML_TYPE_INT64 };
+    rv.type = RVALUE_INT64;
+    rv.gmlStackType = GML_TYPE_INT64;
     rv.int64 = val;
 #endif
     return rv;
 }
 
 static inline RValue RValue_makeBool(bool val) {
-    RValue rv = { .type = RVALUE_BOOL, .gmlStackType = GML_TYPE_BOOL };
+    RValue rv = {0};
+    rv.type = RVALUE_BOOL;
+    rv.gmlStackType = GML_TYPE_BOOL;
     rv.int32 = val ? 1 : 0;
     return rv;
 }
 
 static inline RValue RValue_makeString(const char* val) {
-    RValue rv = { .type = RVALUE_STRING, .ownsReference = false, .gmlStackType = GML_TYPE_STRING };
+    RValue rv = {0};
+    rv.type = RVALUE_STRING;
+    rv.ownsReference = false;
+    rv.gmlStackType = GML_TYPE_STRING;
     rv.string = val;
     return rv;
 }
 
 static inline RValue RValue_makeOwnedString(char* val) {
-    RValue rv = { .type = RVALUE_STRING, .ownsReference = true, .gmlStackType = GML_TYPE_STRING };
+    RValue rv = {0};
+    rv.type = RVALUE_STRING;
+    rv.ownsReference = true;
+    rv.gmlStackType = GML_TYPE_STRING;
     rv.string = val;
     return rv;
 }
 
 static inline RValue RValue_makeUndefined(void) {
-    return (RValue){ .type = RVALUE_UNDEFINED, .gmlStackType = GML_TYPE_VARIABLE };
+    RValue rv = {0};
+    rv.type = RVALUE_UNDEFINED;
+    rv.gmlStackType = GML_TYPE_VARIABLE;
+    return rv;
 }
 
 // Takes ownership: refCount is NOT bumped (caller hands off its ref). The returned RValue decRefs on free.
 // Use this when you have a freshly-allocated array (GMLArray_alloc) or after a GMLArray_incRef.
 static inline RValue RValue_makeArray(GMLArray* arr) {
-    RValue rv = { .type = RVALUE_ARRAY, .ownsReference = true, .gmlStackType = GML_TYPE_VARIABLE };
+    RValue rv = {0};
+    rv.type = RVALUE_ARRAY;
+    rv.ownsReference = true;
+    rv.gmlStackType = GML_TYPE_VARIABLE;
     rv.array = arr;
     return rv;
 }
 
 // Weak view: does not own (no decRef on free). Callers that stash the value long-term must incRef + set ownsString.
 static inline RValue RValue_makeArrayWeak(GMLArray* arr) {
-    RValue rv = { .type = RVALUE_ARRAY, .ownsReference = false, .gmlStackType = GML_TYPE_VARIABLE };
+    RValue rv = {0};
+    rv.type = RVALUE_ARRAY;
+    rv.ownsReference = false;
+    rv.gmlStackType = GML_TYPE_VARIABLE;
     rv.array = arr;
     return rv;
 }
@@ -161,14 +185,20 @@ static inline RValue RValue_makeArrayWeak(GMLArray* arr) {
 #if IS_WAD17_OR_HIGHER_ENABLED
 // Takes ownership: refCount is NOT bumped (caller hands off its ref). The returned RValue decRefs on free.
 static inline RValue RValue_makeMethod(int32_t codeIndex, int32_t boundInstanceId) {
-    RValue rv = { .type = RVALUE_METHOD, .ownsReference = true, .gmlStackType = GML_TYPE_VARIABLE };
+    RValue rv = {0};
+    rv.type = RVALUE_METHOD;
+    rv.ownsReference = true;
+    rv.gmlStackType = GML_TYPE_VARIABLE;
     rv.method = GMLMethod_create(codeIndex, boundInstanceId);
     return rv;
 }
 
 // Weak view: does not own (no decRef on free). Callers that stash the value long-term must incRef + set ownsString.
 static inline RValue RValue_makeMethodWeak(GMLMethod* m) {
-    RValue rv = { .type = RVALUE_METHOD, .ownsReference = false, .gmlStackType = GML_TYPE_VARIABLE };
+    RValue rv = {0};
+    rv.type = RVALUE_METHOD;
+    rv.ownsReference = false;
+    rv.gmlStackType = GML_TYPE_VARIABLE;
     rv.method = m;
     return rv;
 }
@@ -176,21 +206,30 @@ static inline RValue RValue_makeMethodWeak(GMLMethod* m) {
 
 // Weak view: does not own (no decRef on free). Callers that stash the value long-term must incRef + set ownsString.
 static inline RValue RValue_makeStructWeak(Instance* inst) {
-    RValue rv = { .type = RVALUE_STRUCT, .ownsReference = false, .gmlStackType = GML_TYPE_VARIABLE };
+    RValue rv = {0};
+    rv.type = RVALUE_STRUCT;
+    rv.ownsReference = false;
+    rv.gmlStackType = GML_TYPE_VARIABLE;
     rv.structInst = inst;
     return rv;
 }
 
 // Takes ownership AND bumps the refCount. The returned RValue decRefs on free.
 static inline RValue RValue_makeStructAndIncRef(Instance* inst) {
-    RValue rv = { .type = RVALUE_STRUCT, .ownsReference = true, .gmlStackType = GML_TYPE_VARIABLE };
+    RValue rv = {0};
+    rv.type = RVALUE_STRUCT;
+    rv.ownsReference = true;
+    rv.gmlStackType = GML_TYPE_VARIABLE;
     rv.structInst = inst;
     Instance_structIncRef(inst);
     return rv;
 }
 
 static inline RValue RValue_makeAssetRef(int32_t assetIndex, uint8_t assetType) {
-    RValue rv = { .type = RVALUE_ASSETREF, .assetRefType = assetType, .gmlStackType = GML_TYPE_INT32 };
+    RValue rv = {0};
+    rv.type = RVALUE_ASSETREF;
+    rv.assetRefType = assetType;
+    rv.gmlStackType = GML_TYPE_INT32;
     rv.int32 = assetIndex;
     return rv;
 }
@@ -220,7 +259,7 @@ static inline RValue RValue_makeIndependent(RValue val) {
         val.ownsReference = true;
         return val;
     }
-    requireMessageFormatted(!val.ownsReference, "Trying to make independent a RValue (type=%d) that owns a reference, but we don't handle it yet! Did you add a new refcounted value to Butterscotch without implementing RValue_makeIndependent for it?", val.type);
+    requireMessageFormatted(__FILE__, __LINE__, !val.ownsReference, "Trying to make independent a RValue (type=%d) that owns a reference, but we don't handle it yet! Did you add a new refcounted value to Butterscotch without implementing RValue_makeIndependent for it?", val.type);
     return val;
 }
 

--- a/src/spatial_grid.c
+++ b/src/spatial_grid.c
@@ -115,17 +115,17 @@ void SpatialGrid_markInstanceAsDirty(SpatialGrid* grid, Instance* dirtyInstance)
 
 SpatialGridQuery SpatialGrid_prepareQuery(Runner* runner, GMLReal x1, GMLReal y1, GMLReal x2, GMLReal y2, int32_t target) {
     // We do let INSTANCE_ALL through
-    requireMessageFormatted(target >= 0 || target == INSTANCE_ALL, "SpatialGrid: [%s] Query target cannot be instance type %d!", runner->vmContext->currentCodeName, target);
+    requireMessageFormatted(__FILE__, __LINE__, target >= 0 || target == INSTANCE_ALL, "SpatialGrid: [%s] Query target cannot be instance type %d!", runner->vmContext->currentCodeName, target);
 
     SpatialGridRange callerRange = SpatialGrid_computeCellRange(runner->spatialGrid, x1, y1, x2, y2);
     bool filterByObject = target >= 0 && 100000 > target;
     bool filterByInstanceId = target >= 100000;
     uint32_t queryId = ++runner->collisionQueryCounter;
-    return (SpatialGridQuery) {
-        .range = callerRange,
-        .filterByObject = filterByObject,
-        .filterByInstanceId = filterByInstanceId,
-        .matchAll = target == INSTANCE_ALL,
-        .queryId = queryId
-    };
+    SpatialGridQuery ret = {0};
+    ret.range = callerRange;
+    ret.filterByObject = filterByObject;
+    ret.filterByInstanceId = filterByInstanceId;
+    ret.matchAll = target == INSTANCE_ALL;
+    ret.queryId = queryId;
+    return ret;
 }

--- a/src/string_builder.c
+++ b/src/string_builder.c
@@ -12,11 +12,11 @@ StringBuilder StringBuilder_create(size_t initialCapacity) {
     if (STRING_BUILDER_MIN_CAPACITY > initialCapacity) initialCapacity = STRING_BUILDER_MIN_CAPACITY;
     char* buffer = safeMalloc(initialCapacity);
     buffer[0] = '\0';
-    return (StringBuilder) {
-        .buffer = buffer,
-        .length = 0,
-        .capacity = initialCapacity,
-    };
+    StringBuilder ret = {0};
+    ret.buffer = buffer;
+    ret.length = 0;
+    ret.capacity = initialCapacity;
+    return ret;
 }
 
 void StringBuilder_free(StringBuilder* sb) {

--- a/src/text_utils.h
+++ b/src/text_utils.h
@@ -166,6 +166,7 @@ static inline void PreprocessedText_free(PreprocessedText pt) {
 // Preprocesses GML text: converts unescaped # to \n, and \# to literal #.
 // Uses a fused single-pass approach: scans for # and only allocates if one is found.
 static inline PreprocessedText TextUtils_preprocessGmlText(const char* text) {
+    PreprocessedText ret = {0};
     int32_t len = (int32_t) strlen(text);
 
     // Scan until we find a #
@@ -196,18 +197,26 @@ static inline PreprocessedText TextUtils_preprocessGmlText(const char* text) {
                 }
             }
             result[out] = '\0';
-            return (PreprocessedText){ .text = result, .owning = true };
+            ret.text = result;
+            ret.owning = true;
+            return ret;
         }
     }
 
     // No # found, return original pointer without allocating
-    return (PreprocessedText){ .text = text, .owning = false };
+    ret.text = text;
+    ret.owning = false;
+    return ret;
 }
 
 // Preprocess GML text ONLY if the runner is not GameMaker: Studio 2
 static inline PreprocessedText TextUtils_preprocessGmlTextIfNeeded(Runner* runner, const char* text) {
-    if (DataWin_isVersionAtLeast(runner->dataWin, 2, 0, 0, 0))
-        return (PreprocessedText){ .text = text, .owning = false };
+    if (DataWin_isVersionAtLeast(runner->dataWin, 2, 0, 0, 0)) {
+        PreprocessedText ret = {0};
+        ret.text = text;
+        ret.owning = false;
+        return ret;
+    }
     return TextUtils_preprocessGmlText(text);
 }
 
@@ -248,10 +257,16 @@ static inline int32_t TextUtils_skipNewline(const char* text, int32_t lineEnd, i
 // Port of yyFontManager.prototype.Split_TextBlock from GameMaker-HTML5 to C.
 // Pass "0 > maxWidth" to disable wrapping (returns the original pointer non-owning).
 static inline PreprocessedText TextUtils_wrapText(Font* font, const char* text, int32_t maxWidth) {
-    if (text == nullptr) return (PreprocessedText) { .text = text, .owning = false };
+    PreprocessedText ret = {0};
+    int32_t len = 0;
+    if (text != nullptr)
+        len = (int32_t) strlen(text);
 
-    int32_t len = (int32_t) strlen(text);
-    if (0 == len) return (PreprocessedText) { .text = text, .owning = false };
+    if (0 == len) {
+        ret.text = text;
+        ret.owning = false;
+        return ret;
+    }
 
     int32_t linewidth = (0 > maxWidth) ? 10000000 : maxWidth; // means nothing will "wrap"
 
@@ -259,6 +274,9 @@ static inline PreprocessedText TextUtils_wrapText(Font* font, const char* text, 
     char* out = safeMalloc((size_t) len * 2 + 1);
     int32_t outLen = 0;
     bool wroteAny = false;
+
+    ret.text = out;
+    ret.owning = true;
 
     // put newlines in
     const char* pNew = text;
@@ -322,7 +340,7 @@ static inline PreprocessedText TextUtils_wrapText(Font* font, const char* text, 
                 // NOT a new line, but we didn't move on... fatal error. Probably a single char doesn't even fit!
                 if (end == start) {
                     out[outLen] = '\0';
-                    return (PreprocessedText){ .text = out, .owning = true };
+                    return ret;
                 }
 
                 // If we don't END on a "space", OR if the next character isn't a space AS WELL.
@@ -366,7 +384,7 @@ static inline PreprocessedText TextUtils_wrapText(Font* font, const char* text, 
         start = ++end;
     }
     out[outLen] = '\0';
-    return (PreprocessedText) { .text = out, .owning = true };
+    return ret;
 }
 
 static inline char* TextUtils_trimTrailingWhitespace(char* str) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common.h"
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -17,9 +18,7 @@
     for (typeof(count) index = 0; index < (count); index++) \
     for (type* item = &(array)[index]; item; item = NULL)
 
-// The "typeof((typeof(n))0" is used to remove the "const" from the typeof
-
-#define repeat(n, it) for (typeof((typeof(n))0) it = 0; it < (n); it++)
+#define repeat(n, it) for (typeof(n) it = 0; it < (n); ++it)
 
 #define require(condition) \
     do { \
@@ -37,13 +36,17 @@ abort(); \
 } \
 } while (0)
 
-#define requireMessageFormatted(condition, fmt, ...) \
-do { \
-if (!(condition)) { \
-fprintf(stderr, "Requirement failed at %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
-abort(); \
-} \
-} while (0)
+static void requireMessageFormatted(const char *file, int line, bool condition, const char *fmt, ...) {
+    if (condition)
+        return;
+    va_list args;
+    fprintf(stderr, "Requirement failed at %s:%d: ", file, line);
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fputc('\n', stderr);
+    abort();
+}
 
 #define requireNotNull(ptr) ({ \
 typeof(ptr) _val = (ptr); \

--- a/src/vm.c
+++ b/src/vm.c
@@ -289,7 +289,7 @@ static void storeIntoArraySlot(RValue* slot, RValue val) {
 // Returns the (possibly newly-forked) GMLArray* now in *slot.
 static GMLArray* VM_arrayWriteAt(VMContext* ctx, RValue* slot, int32_t index, RValue val) {
     require(slot != nullptr);
-    requireMessageFormatted(index >= 0, "Trying to write to an array using a negative index! Index: %d", index);
+    requireMessageFormatted(__FILE__, __LINE__, index >= 0, "Trying to write to an array using a negative index! Index: %d", index);
 
     void* intendedOwner;
 #if IS_WAD17_OR_HIGHER_ENABLED
@@ -397,6 +397,7 @@ static const char* varTypeToString(uint8_t varType) {
 // for plain variable access.
 static ArrayAccess popArrayAccess(VMContext* ctx, uint32_t varRef) {
     uint8_t varType = (varRef >> 24) & 0xF8;
+    ArrayAccess ret = {0};
     if (varType == VARTYPE_ARRAY) {
         // For array reads, GMS pushes: instanceType then arrayIndex (arrayIndex on top)
         int32_t arrayIndex = stackPopInt32(ctx);
@@ -408,7 +409,11 @@ static ArrayAccess popArrayAccess(VMContext* ctx, uint32_t varRef) {
             instanceType = resolveInstanceStackTop(ctx);
         }
 
-        return (ArrayAccess){ .arrayIndex = arrayIndex, .instanceType = instanceType, .isArray = true, .hasInstanceType = true };
+        ret.arrayIndex = arrayIndex;
+        ret.instanceType = instanceType;
+        ret.isArray = true;
+        ret.hasInstanceType = true;
+        return ret;
     }
     if (varType == VARTYPE_STACKTOP) {
         int32_t instanceType = stackPopInt32(ctx);
@@ -418,9 +423,16 @@ static ArrayAccess popArrayAccess(VMContext* ctx, uint32_t varRef) {
         if (IS_WAD17_OR_HIGHER(ctx) && instanceType == INSTANCE_STACKTOP) {
             instanceType = resolveInstanceStackTop(ctx);
         }
-        return (ArrayAccess){ .arrayIndex = -1, .isArray = false, .hasInstanceType = true, .instanceType = instanceType };
+        ret.arrayIndex = -1;
+        ret.isArray = false;
+        ret.hasInstanceType = true;
+        ret.instanceType = instanceType;
+        return ret;
     }
-    return (ArrayAccess){ .arrayIndex = -1, .isArray = false, .hasInstanceType = false };
+    ret.arrayIndex = -1;
+    ret.isArray = false;
+    ret.hasInstanceType = false;
+    return ret;
 }
 
 // ===[ Variable Resolution ]===
@@ -740,15 +752,20 @@ static RValue resolveVariableRead(VMContext* ctx, int32_t instanceType, uint32_t
             return RValue_makeMethod(codeIndex, -1);
         }
         // Then try registered built-ins
+        RValue rv = {0};
         ptrdiff_t bidx = shgeti(ctx->builtinMap, (char*) varDef->name);
         if (bidx >= 0) {
             BuiltinFunc bf = ctx->builtinMap[bidx].value;
-            RValue rv = { .type = RVALUE_METHOD, .ownsReference = true, .gmlStackType = GML_TYPE_VARIABLE };
+            rv.type = RVALUE_METHOD;
+            rv.ownsReference = true;
+            rv.gmlStackType = GML_TYPE_VARIABLE;
             rv.method = GMLMethod_createBuiltin(bf, -1);
             return rv;
         }
         // Unresolved: return a method stub so CallV can log a single "unknown function" and return undefined instead of bailing out with a scary "unresolvable function reference" error.
-        RValue rv = { .type = RVALUE_METHOD, .ownsReference = true, .gmlStackType = GML_TYPE_VARIABLE };
+        rv.type = RVALUE_METHOD;
+        rv.ownsReference = true;
+        rv.gmlStackType = GML_TYPE_VARIABLE;
         rv.method = GMLMethod_createUnresolved(varDef->name, -1);
         return rv;
     }
@@ -1637,7 +1654,7 @@ static void handleDiv(VMContext* ctx, uint32_t instr) {
     GMLReal divisor = RValue_toReal(b);
     // In GameMaker's native runner, ONLY integer/integer division throws a hard error on zero, float/variable types rely on IEEE 754 (produces NaN)
     if ((type1 == GML_TYPE_INT32 || type1 == GML_TYPE_INT64) && (type2 == GML_TYPE_INT32 || type2 == GML_TYPE_INT64)) {
-        requireMessageFormatted(divisor != 0.0, "VM: [%s] DoDiv :: Divide by zero", ctx->currentCodeName);
+        requireMessageFormatted(__FILE__, __LINE__, divisor != 0.0, "VM: [%s] DoDiv :: Divide by zero", ctx->currentCodeName);
     }
     GMLReal result = RValue_toReal(a) / divisor;
     RValue_free(&a);
@@ -1649,7 +1666,7 @@ static void handleRem(VMContext* ctx, uint32_t instr) {
     RValue b = stackPop(ctx);
     RValue a = stackPop(ctx);
     int64_t divisor = RValue_toInt64(b);
-    requireMessageFormatted(divisor != 0, "VM: [%s] DoRem :: Divide by zero", ctx->currentCodeName);
+    requireMessageFormatted(__FILE__, __LINE__, divisor != 0, "VM: [%s] DoRem :: Divide by zero", ctx->currentCodeName);
     int64_t result = RValue_toInt64(a) / divisor;
     RValue_free(&a);
     RValue_free(&b);
@@ -1660,7 +1677,7 @@ static void handleMod(VMContext* ctx, uint32_t instr) {
     RValue b = stackPop(ctx);
     RValue a = stackPop(ctx);
     GMLReal divisor = RValue_toReal(b);
-    requireMessageFormatted(divisor != 0.0, "VM: [%s] DoMod :: Divide by zero", ctx->currentCodeName);
+    requireMessageFormatted(__FILE__, __LINE__, divisor != 0.0, "VM: [%s] DoMod :: Divide by zero", ctx->currentCodeName);
     GMLReal result = GMLReal_fmod(RValue_toReal(a), divisor);
     RValue_free(&a);
     RValue_free(&b);
@@ -2802,7 +2819,10 @@ static void handleBreakPushRef(VMContext* ctx, const uint8_t* extraData) {
                 stackPushTyped(ctx, RValue_makeMethod(cache->scriptCodeIndex, -1), GML_TYPE_VARIABLE);
                 return;
             }
-            RValue rv = { .type = RVALUE_METHOD, .ownsReference = true, .gmlStackType = GML_TYPE_VARIABLE };
+            RValue rv = {0};
+            rv.type = RVALUE_METHOD;
+            rv.ownsReference = true;
+            rv.gmlStackType = GML_TYPE_VARIABLE;
             if (cache->builtin != nullptr) {
                 rv.method = GMLMethod_createBuiltin((BuiltinFunc) cache->builtin, -1);
             } else {
@@ -3476,7 +3496,7 @@ VMContext* VM_create(DataWin* dataWin) {
     // Validate that no code entry exceeds MAX_CODE_LOCALS (the VM uses stack-allocated arrays of this size)
     repeat(dataWin->code.count, i) {
         CodeEntry* entry = &dataWin->code.entries[i];
-        requireMessageFormatted(MAX_CODE_LOCALS > entry->localsCount, "Code %s has too many locals!", entry->name);
+        requireMessageFormatted(__FILE__, __LINE__, MAX_CODE_LOCALS > entry->localsCount, "Code %s has too many locals!", entry->name);
     }
 
     VMBuiltins_checkIfBuiltinVarTableIsSorted();
@@ -3764,20 +3784,19 @@ RValue VM_callCodeIndex(VMContext* ctx, int32_t codeIndex, RValue* args, int32_t
     CodeEntry* code = &ctx->dataWin->code.entries[codeIndex];
 
     // Save current frame
-    CallFrame frame = (CallFrame) {
-        .savedIP = ctx->ip,
-        .savedCodeEnd = ctx->codeEnd,
-        .savedBytecodeBase = ctx->bytecodeBase,
-        .savedLocals = ctx->localVars,
-        .savedLocalsCount = ctx->localVarCount,
-        .savedCodeName = ctx->currentCodeName,
-        .savedSavearefBalance = ctx->savearefBalance,
-        .savedCodeLocalsSlotMap = ctx->currentCodeLocalsSlotMap,
-        .savedScriptArgs = ctx->scriptArgs,
-        .savedScriptArgCount = ctx->scriptArgCount,
-        .savedCurrentCodeIndex = ctx->currentCodeIndex,
-        .parent = ctx->callStack,
-    };
+    CallFrame frame = {0};
+    frame.savedIP = ctx->ip;
+    frame.savedCodeEnd = ctx->codeEnd;
+    frame.savedBytecodeBase = ctx->bytecodeBase;
+    frame.savedLocals = ctx->localVars;
+    frame.savedLocalsCount = ctx->localVarCount;
+    frame.savedCodeName = ctx->currentCodeName;
+    frame.savedSavearefBalance = ctx->savearefBalance;
+    frame.savedCodeLocalsSlotMap = ctx->currentCodeLocalsSlotMap;
+    frame.savedScriptArgs = ctx->scriptArgs;
+    frame.savedScriptArgCount = ctx->scriptArgCount;
+    frame.savedCurrentCodeIndex = ctx->currentCodeIndex;
+    frame.parent = ctx->callStack;
     ctx->callStack = &frame;
     ctx->callDepth++;
 
@@ -4339,6 +4358,8 @@ void VM_buildCrossReferences(VMContext* ctx) {
     }
 }
 
+struct VMDisasOpcodeEntry { uint32_t key; bool value; };
+
 void VM_disassemble(VMContext* ctx, int32_t codeIndex) {
     DataWin* dw = ctx->dataWin;
     require(dw->code.count > (uint32_t) codeIndex);
@@ -4378,7 +4399,7 @@ void VM_disassemble(VMContext* ctx, int32_t codeIndex) {
     uint32_t codeLength = code->length;
 
     // Pass 1: collect branch targets for labels
-    struct { uint32_t key; bool value; }* branchTargets = nullptr;
+    struct VMDisasOpcodeEntry *branchTargets = nullptr;
     {
         uint32_t ip = 0;
         while (codeLength > ip) {

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -130,7 +130,7 @@ static int32_t dsListCreate(Runner* runner) {
             return i;
         }
     }
-    DsList newList = { .items = nullptr, .freed = false };
+    DsList newList = {0};
     int32_t id = poolSize;
     arrput(runner->dsListPool, newList);
     return id;
@@ -153,7 +153,7 @@ static int32_t dsQueueCreate(Runner* runner) {
             return i;
         }
     }
-    DsQueue q = { .items = nullptr, .freed = false };
+    DsQueue q = {0};
     int32_t id = poolSize;
     arrput(runner->dsQueuePool, q);
     return id;
@@ -414,7 +414,7 @@ void VMBuiltins_checkIfBuiltinVarTableIsSorted(void) {
     size_t count = sizeof(BUILTIN_VAR_TABLE) / sizeof(BUILTIN_VAR_TABLE[0]);
     for (size_t i = 1; count > i; i++) {
         int cmp = strcmp(BUILTIN_VAR_TABLE[i - 1].name, BUILTIN_VAR_TABLE[i].name);
-        requireMessageFormatted(cmp < 0, "BUILTIN_VAR_TABLE not strictly sorted at index %zu: '%s' vs '%s' (cmp=%d). Re-sort (LC_ALL=C) or remove duplicates!", i, BUILTIN_VAR_TABLE[i - 1].name, BUILTIN_VAR_TABLE[i].name, cmp);
+        requireMessageFormatted(__FILE__, __LINE__, cmp < 0, "BUILTIN_VAR_TABLE not strictly sorted at index %zu: '%s' vs '%s' (cmp=%d). Re-sort (LC_ALL=C) or remove duplicates!", i, BUILTIN_VAR_TABLE[i - 1].name, BUILTIN_VAR_TABLE[i].name, cmp);
     }
 }
 
@@ -4093,7 +4093,11 @@ static RValue builtin_ds_list_read(VMContext* ctx, RValue* args, MAYBE_UNUSED in
         bytes[i] = (uint8_t) ((hi << 4) | lo);
     }
 
-    DsReadStream s = { .data = bytes, .size = byteLen, .pos = 0, .error = false };
+    DsReadStream s = {0};
+    s.data = bytes;
+    s.size = byteLen;
+    s.pos = 0;
+    s.error = false;
     uint32_t magic = dsStreamReadU32(&s);
     int32_t version;
     // 301 = ~BC13 (REAL/STRING/ARRAY only)
@@ -4365,7 +4369,9 @@ static RValue builtin_ds_queue_read(VMContext* ctx, RValue* args, MAYBE_UNUSED i
         bytes[i] = (uint8_t) ((hi << 4) | lo);
     }
 
-    DsReadStream s = { .data = bytes, .size = byteLen, .pos = 0, .error = false };
+    DsReadStream s = {0};
+    s.data = bytes;
+    s.size = byteLen;
     uint32_t magic = dsStreamReadU32(&s);
     int32_t version;
     if (magic == 202) {
@@ -5676,15 +5682,15 @@ static RValue builtin_file_text_open_read(VMContext* ctx, RValue* args, int32_t 
         content = safeStrdup("");
     }
 
-    runner->openTextFiles[slot] = (OpenTextFile) {
-        .content = content,
-        .writeBuffer = nullptr,
-        .filePath = nullptr,
-        .readPos = 0,
-        .contentLen = (int32_t) strlen(content),
-        .isWriteMode = false,
-        .isOpen = true,
-    };
+    OpenTextFile file = {0};
+    file.content = content;
+    file.writeBuffer = nullptr;
+    file.filePath = nullptr;
+    file.readPos = 0;
+    file.contentLen = (int32_t) strlen(content);
+    file.isWriteMode = false;
+    file.isOpen = true;
+    runner->openTextFiles[slot] = file;
 
     return RValue_makeReal((GMLReal) slot);
 }
@@ -5700,15 +5706,15 @@ static RValue builtin_file_text_open_write(VMContext* ctx, RValue* args, int32_t
         abort();
     }
 
-    runner->openTextFiles[slot] = (OpenTextFile) {
-        .content = nullptr,
-        .writeBuffer = safeStrdup(""),
-        .filePath = safeStrdup(path),
-        .readPos = 0,
-        .contentLen = 0,
-        .isWriteMode = true,
-        .isOpen = true,
-    };
+    OpenTextFile file = {0};
+    file.content = nullptr;
+    file.writeBuffer = safeStrdup("");
+    file.filePath = safeStrdup(path);
+    file.readPos = 0;
+    file.contentLen = 0;
+    file.isWriteMode = true;
+    file.isOpen = true;
+    runner->openTextFiles[slot] = file;
 
     return RValue_makeReal((GMLReal) slot);
 }
@@ -6013,7 +6019,10 @@ static RValue builtin_file_bin_open(VMContext* ctx, RValue* args, int32_t argCou
     void* handle = fs->vtable->binaryOpen(fs, path, mode);
     if (handle == nullptr) return RValue_makeReal(-1.0);
 
-    runner->openBinaryFiles[slot] = (OpenBinaryFile) { .handle = handle, .isOpen = true };
+    OpenBinaryFile file = {0};
+    file.handle = handle;
+    file.isOpen = true;
+    runner->openBinaryFiles[slot] = file;
     return RValue_makeReal((GMLReal) slot);
 }
 
@@ -7625,7 +7634,9 @@ static int32_t gmlAsyncBufferKick(Runner* runner, AsyncBufferOp* ops, int32_t op
     repeat(opCount, i) {
         if (!gmlAsyncBufferRunOp(runner, &ops[i], groupName)) allOk = false;
     }
-    AsyncSaveLoadCompletion completion = { .requestId = requestId, .status = allOk ? 1 : 0, .error = 0 };
+    AsyncSaveLoadCompletion completion = {0};
+    completion.requestId = requestId;
+    completion.status = allOk ? 1 : 0;
     arrput(runner->asyncSaveLoadQueue, completion);
     return requestId;
 }
@@ -7708,11 +7719,11 @@ static RValue builtin_filename_change_ext(MAYBE_UNUSED VMContext* ctx, MAYBE_UNU
 
     if (last != nullptr && last != 0) {
         long index = last - fname;
-        char* new = safeMalloc(index + strlen(newext) + 1);
-        memcpy(new, fname, (size_t) index);
-        memcpy(new + index, newext, (size_t) strlen(newext));
-        new[index + strlen(newext)] = '\0';
-        RValue result = RValue_makeOwnedString(new);
+        char* new_name = safeMalloc(index + strlen(newext) + 1);
+        memcpy(new_name, fname, (size_t) index);
+        memcpy(new_name + index, newext, (size_t) strlen(newext));
+        new_name[index + strlen(newext)] = '\0';
+        RValue result = RValue_makeOwnedString(new_name);
 
         free(fname);
         free(newext);
@@ -10623,7 +10634,8 @@ static RValue builtin_action_draw_sprite(VMContext* ctx, RValue* args, MAYBE_UNU
 static TileLayerState* getOrCreateTileLayer(Runner* runner, int32_t depth) {
     ptrdiff_t idx = hmgeti(runner->tileLayerMap, depth);
     if (0 > idx) {
-        TileLayerState defaultVal = { .visible = true, .offsetX = 0.0f, .offsetY = 0.0f };
+        TileLayerState defaultVal = {0};
+        defaultVal.visible = true;
         hmput(runner->tileLayerMap, depth, defaultVal);
         idx = hmgeti(runner->tileLayerMap, depth);
     }
@@ -11070,16 +11082,12 @@ static RValue builtin_layer_create(VMContext* ctx, RValue* args, int32_t argCoun
         name = RValue_toString(args[1]);
     }
     uint32_t id = Runner_getNextLayerId(runner);
-    RuntimeLayer runtimeLayer = {
-        .id = id,
-        .depth = depth,
-        .visible = true,
-        .xOffset = 0.0f, .yOffset = 0.0f,
-        .hSpeed = 0.0f, .vSpeed = 0.0f,
-        .dynamic = true,
-        .dynamicName = name, // ownership transferred (nullptr if not provided)
-        .elements = nullptr,
-    };
+    RuntimeLayer runtimeLayer = {0};
+    runtimeLayer.id = id;
+    runtimeLayer.depth = depth;
+    runtimeLayer.visible = true;
+    runtimeLayer.dynamic = true;
+    runtimeLayer.dynamicName = name, // ownership transferred (nullptr if not provided)
     arrput(runner->runtimeLayers, runtimeLayer);
     runner->drawableListStructureDirty = true;
     return RValue_makeReal((GMLReal) id);
@@ -11126,15 +11134,12 @@ static RValue builtin_layer_background_create(VMContext* ctx, RValue* args, MAYB
     bg->alpha = 1.0f;
     bg->xOffset = 0.0f;
     bg->yOffset = 0.0f;
-    RuntimeLayerElement el = {
-        .id = Runner_getNextLayerId(runner),
-        .type = RuntimeLayerElementType_Background,
-        .visible = true,
-        .alpha = 1.0f,
-        .backgroundElement = bg,
-        .spriteElement = nullptr,
-        .tileElement = nullptr,
-    };
+    RuntimeLayerElement el = {0};
+    el.id = Runner_getNextLayerId(runner);
+    el.type = RuntimeLayerElementType_Background;
+    el.visible = true;
+    el.alpha = 1.0f;
+    el.backgroundElement = bg;
     arrput(runtimeLayer->elements, el);
     return RValue_makeReal((GMLReal) el.id);
 }

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -243,37 +243,34 @@ void startRunner(const char* gamePath, const char* savesPath) {
         }
     }
 
-    DataWin* dataWin = DataWin_parse(
-        gamePath,
-        (DataWinParserOptions) {
-            .parseGen8 = true,
-            .parseOptn = true,
-            .parseLang = true,
-            .parseExtn = true,
-            .parseSond = true,
-            .parseAgrp = true,
-            .parseSprt = true,
-            .parseBgnd = true,
-            .parsePath = true,
-            .parseScpt = true,
-            .parseGlob = true,
-            .parseShdr = true,
-            .parseFont = true,
-            .parseTmln = true,
-            .parseObjt = true,
-            .parseRoom = true,
-            .parseTpag = true,
-            .parseCode = true,
-            .parseVari = true,
-            .parseFunc = true,
-            .parseStrg = true,
-            .parseTxtr = true,
-            .parseAudo = true,
-            .skipLoadingPreciseMasksForNonPreciseSprites = true,
-            .lazyLoadRooms = false,
-            .eagerlyLoadedRooms = nullptr
-        }
-    );
+    DataWinParserOptions options = {0};
+    options.parseGen8 = true;
+    options.parseOptn = true;
+    options.parseLang = true;
+    options.parseExtn = true;
+    options.parseSond = true;
+    options.parseAgrp = true;
+    options.parseSprt = true;
+    options.parseBgnd = true;
+    options.parsePath = true;
+    options.parseScpt = true;
+    options.parseGlob = true;
+    options.parseShdr = true;
+    options.parseFont = true;
+    options.parseTmln = true;
+    options.parseObjt = true;
+    options.parseRoom = true;
+    options.parseTpag = true;
+    options.parseCode = true;
+    options.parseVari = true;
+    options.parseFunc = true;
+    options.parseStrg = true;
+    options.parseTxtr = true;
+    options.parseAudo = true;
+    options.skipLoadingPreciseMasksForNonPreciseSprites = true;
+    options.lazyLoadRooms = false;
+    options.eagerlyLoadedRooms = nullptr;
+    DataWin* dataWin = DataWin_parse(gamePath, options);
 
     // return strdup(dataWin->gen8.name);
 

--- a/vendor/bzip2/bzlib.c
+++ b/vendor/bzip2/bzlib.c
@@ -684,7 +684,7 @@ Bool unRLE_obuf_to_output_FAST ( DState* s )
 
 
 /*---------------------------------------------------*/
-__inline__ Int32 BZ2_indexIntoF ( Int32 indx, Int32 *cftab )
+Int32 BZ2_indexIntoF ( Int32 indx, Int32 *cftab )
 {
    Int32 nb, na, mid;
    nb = 0;


### PR DESCRIPTION
This is ready but depends on #176 so its marked as draft until that gets merged.

Adds support for building with GCC 2.95.

GCC 2.95's C mode, even with `-std=gnu9x`, doesn't support mixed declarations and code, which makes it impossible to adapt butterscotch to support it without *major* effort.  It would basically be a full C89 conversion, and would be a monumental diff.  This is unacceptable.
The solution was to target GCC 2.95's C++ mode.  C++ has supported mixed declarations and code for much longer, so I just made the changes required to build with `g++ -fpermissive`.  You must use `-fpermissive` because otherwise GCC will error whenever you implicitly cast a `void *` to another pointer type.