### PR TITLE
Fix timers on Windows and window title in GLFW2/SDL1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,14 @@ CC := cc
 
 CFLAGS := -O2 -DNDEBUG
 
+ifeq ($(OS),Windows_NT)
+OS := Windows
+else
 OS := $(shell uname -s)
+ifneq ($(filter MINGW% MSYS% CYGWIN%,$(OS)),)
+OS := Windows
+endif
+endif
 
 DEFINES := -DENABLE_VM_GML_PROFILER \
 		   -DENABLE_VM_OPCODE_PROFILER \
@@ -44,21 +51,26 @@ endif
 
 # TODO: add support for non-desktop backends
 SRCS += $(wildcard src/desktop/*.c) $(wildcard src/desktop/backends/$(DESKTOP_BACKEND).c)
+ifeq ($(OS),Windows)
+PKG_CONFIG_FLAGS := --static
+else
+PKG_CONFIG_FLAGS :=
+endif
 INCLUDES += -Isrc/desktop
 ifeq ($(DESKTOP_BACKEND),glfw3)
-GLFW3_LIBS += $(shell pkg-config --libs glfw3)
+GLFW3_LIBS += $(shell pkg-config $(PKG_CONFIG_FLAGS) --libs glfw3)
 LIBS += $(GLFW3_LIBS)
 DEFINES += -DUSE_GLFW3
 ENABLE_GLAD := 1
 endif
 ifeq ($(DESKTOP_BACKEND),glfw2)
-GLFW2_LIBS += $(shell pkg-config --libs libglfw)
+GLFW2_LIBS += $(shell pkg-config $(PKG_CONFIG_FLAGS) --libs libglfw)
 LIBS += $(GLFW2_LIBS)
 DEFINES += -DUSE_GLFW2
 ENABLE_GLAD := 1
 endif
 ifeq ($(DESKTOP_BACKEND),sdl1)
-SDL1_LIBS += $(shell pkg-config --libs sdl)
+SDL1_LIBS += $(shell pkg-config $(PKG_CONFIG_FLAGS) --libs sdl)
 LIBS += $(SDL1_LIBS)
 DEFINES += -DUSE_SDL1
 endif

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 endif
 
 ifeq ($(OS),Windows)
-LIBS += -static
+LIBS += -static -lwinmm
 else
 ifeq ($(OS),Darwin)
 LIBS += -lobjc

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -143,6 +143,8 @@ bool platformInit(int reqW, int reqH, const char *title, bool headless) {
         return false;
     }
 
+    glfwSetWindowTitle(title);
+
     glfwSwapInterval(0); // Disable v-sync, we control timing ourselves
 
     // Set up keyboard input
@@ -196,7 +198,8 @@ void *platformGetProcAddress(const char *name) {
     // This just implements it in a way that's fixed
     // so it can be passed to GLAD.
     void *ret = (void *)wglGetProcAddress(name);
-    if (ret == 0 || ret == (void *)1 || ret == (void *)2 || ret == (void *)3 || ret == (void *)-1) { // ChatGPT says this is needed because some OpenGL drivers do this
+    // Fallback for driver-specific error codes and legacy OpenGL core functions.
+    if (ret == 0 || ret == (void *)1 || ret == (void *)2 || ret == (void *)3 || ret == (void *)-1) {
         HMODULE handle = GetModuleHandle("opengl32.dll");
         if (handle)
             ret = (void *)GetProcAddress(handle, name);
@@ -220,17 +223,9 @@ bool platformHandleEvents(void) {
 
 void platformSleepUntil(double time) {
     double remaining = time - platformGetTime();
-    if (remaining > 0.002) {
-#ifdef _WIN32
-        Sleep((DWORD) ((remaining - 0.001) * 1000));
-#else
-        struct timespec ts = {
-            .tv_sec = 0,
-            .tv_nsec = (long) ((remaining - 0.001) * 1e9)
-        };
-        nanosleep(&ts, NULL);
-#endif
-    }
+    if (remaining > 0.002) // glfwSleep takes seconds as a double
+        glfwSleep(remaining - 0.001);
+
     while (platformGetTime() < time) {
         // Spin-wait for the remaining sub-millisecond
     }

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -71,6 +71,8 @@ bool platformInit(int reqW, int reqH, const char *title, bool headless) {
         }
     }
 
+    SDL_WM_SetCaption(title, NULL);
+
     SDL_EnableKeyRepeat(0, 0);
 
     return true;

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -10,6 +10,7 @@
 #include <signal.h>
 #ifdef _WIN32
 #include <windows.h>
+#include <mmsystem.h>
 #endif
 #ifdef __GLIBC__
 #include <malloc.h>
@@ -772,6 +773,9 @@ static void onCrashSignal(int sig) {
 // ===[ MAIN ]===
 int main(int argc, char* argv[]) {
     setbuf(stderr, NULL);
+#ifdef _WIN32
+    timeBeginPeriod(1);
+#endif
 
     CommandLineArgs args;
     parseCommandLineArgs(&args, argc, argv);
@@ -1651,6 +1655,9 @@ int main(int argc, char* argv[]) {
             arrfree(newArguments);
         }
 
+#ifdef _WIN32
+        timeEndPeriod(1);
+#endif
         printf("Bye! :3\n");
     }
 }


### PR DESCRIPTION
Since e3c39ec, games were running slower on Windows, at least on the GLFW backends, since SDL didn't seem to be affected.

Doing a quick look, I noticed SDL adjusts the timers on Windows while GLFW doesn't, so now those are explicity set.

Also fix window titles on these backends (missed change due to desktop backend merge)