### PR TITLE
Set OpenGL context versions in GLFW2

### DIFF
--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -150,6 +150,28 @@ bool platformInit(int32_t reqW, int32_t reqH, const char *title, bool headless) 
         return false;
     }
 
+#ifdef GLFW_OPENGL_VERSION_MAJOR
+    if (gfx == SOFTWARE) {
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 1);
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 0);
+    } else if (gfx == LEGACY_GL) {
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 1);
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 1);
+    } else {
+#ifdef ENABLE_GLES
+        glfwOpenWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 0);
+#else
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MAJOR, 3);
+        glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, 2);
+        glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+        glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        glfwOpenWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
+#endif
+    }
+#endif
+
     // Init GLFW
     if (!glfwInit()) {
         fprintf(stderr, "Failed to initialize GLFW\n");


### PR DESCRIPTION
I initially had this in GLFW2 wayy back but removed it because GLFW 2.6 didn't have these macros and it seemed to not be needed since Linux and Windows didn't care if you set the version or not.  But now that I know macOS does care, I've added the code back behind a check for the macro's existence, the `#ifdef` should allow the backend to still build on GLFW 2.6 (though the modern-gl renderer might not work on macOS with 2.6).