### PR TITLE
Make spin-waiting a little more power efficient on desktop

### DIFF
--- a/src/collision.h
+++ b/src/collision.h
@@ -431,15 +431,3 @@ static inline bool Collision_instancesOverlapPrecise(Runner* runner, Instance* a
 
     return false;
 }
-
-#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
-    #include <immintrin.h>
-    #define YIELD() _mm_pause()
-#elif defined(_M_ARM64) || defined(_M_ARM)
-    #include <intrin.h>
-    #define YIELD() __yield()
-#elif defined(__aarch64__) || defined(__arm__) && (__ARM_ARCH >= 7)
-    #define YIELD() __asm__ volatile("yield" ::: "memory")
-#else
-    #define YIELD() ((void)0)
-#endif

--- a/src/collision.h
+++ b/src/collision.h
@@ -431,3 +431,15 @@ static inline bool Collision_instancesOverlapPrecise(Runner* runner, Instance* a
 
     return false;
 }
+
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+    #include <immintrin.h>
+    #define YIELD() _mm_pause()
+#elif defined(_M_ARM64) || defined(_M_ARM)
+    #include <intrin.h>
+    #define YIELD() __yield()
+#elif defined(__aarch64__) || defined(__arm__) && (__ARM_ARCH >= 7)
+    #define YIELD() __asm__ volatile("yield" ::: "memory")
+#else
+    #define YIELD() ((void)0)
+#endif

--- a/src/common.h
+++ b/src/common.h
@@ -35,3 +35,15 @@
         #define MAYBE_UNUSED
     #endif
 #endif
+
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+    #include <immintrin.h>
+    #define YIELD() _mm_pause()
+#elif defined(_M_ARM64) || defined(_M_ARM)
+    #include <intrin.h>
+    #define YIELD() __yield()
+#elif defined(__aarch64__) || defined(__arm__) && (__ARM_ARCH >= 7)
+    #define YIELD() __asm__ volatile("yield" ::: "memory")
+#else
+    #define YIELD() ((void)0)
+#endif

--- a/src/common.h
+++ b/src/common.h
@@ -37,13 +37,25 @@
 #endif
 
 #if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
-    #include <immintrin.h>
-    #define YIELD() _mm_pause()
+    #if defined(__GNUC__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 4))
+        #define YIELD() __asm__ volatile("rep; nop" ::: "memory")
+    #else
+        #include <immintrin.h>
+        #define YIELD() _mm_pause()
+    #endif
 #elif defined(_M_ARM64) || defined(_M_ARM)
     #include <intrin.h>
     #define YIELD() __yield()
-#elif defined(__aarch64__) || defined(__arm__) && (__ARM_ARCH >= 7)
-    #define YIELD() __asm__ volatile("yield" ::: "memory")
+#elif defined(__aarch64__) || (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7))
+    #if defined(__GNUC__) && (__GNUC__ < 5)
+        #define YIELD() __asm__ volatile("yield" ::: "memory")
+    #else
+        #include <arm_acle.h>
+        #define YIELD() __yield()
+    #endif
+#elif defined(__riscv)
+    #define YIELD() __asm__ volatile("pause" ::: "memory")
 #else
     #define YIELD() ((void)0)
 #endif
+

--- a/src/common.h
+++ b/src/common.h
@@ -38,9 +38,9 @@
 
 #if defined(__GNUC__) || defined(__clang__)
     #if defined(__x86_64__) || defined(__i386__) || defined(__riscv)
-        #define YIELD() __asm__ volatile("pause" ::: "memory")
+        #define YIELD() __asm__ volatile("rep; nop" : : : "memory")
     #elif defined(__aarch64__) || (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7))
-        #define YIELD() __asm__ volatile("yield" ::: "memory")
+        #define YIELD() __asm__ volatile("yield" : : : "memory")
     #else
         #define YIELD() ((void)0)
     #endif

--- a/src/common.h
+++ b/src/common.h
@@ -38,7 +38,7 @@
 
 #ifdef __GNUC__
     #if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
-        #if defined(__GNUC__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 4))
+        #if ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 4))
             #define YIELD() __asm__ volatile("rep; nop" ::: "memory")
         #else
             #include <immintrin.h>
@@ -48,7 +48,7 @@
         #include <intrin.h>
         #define YIELD() __yield()
     #elif defined(__aarch64__) || (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7))
-        #if defined(__GNUC__) && (__GNUC__ < 5)
+        #if (__GNUC__ < 5)
             #define YIELD() __asm__ volatile("yield" ::: "memory")
         #else
             #include <arm_acle.h>

--- a/src/common.h
+++ b/src/common.h
@@ -36,26 +36,20 @@
     #endif
 #endif
 
-#ifdef __GNUC__
-    #if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
-        #if ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 4))
-            #define YIELD() __asm__ volatile("rep; nop" ::: "memory")
-        #else
-            #include <immintrin.h>
-            #define YIELD() _mm_pause()
-        #endif
-    #elif defined(_M_ARM64) || defined(_M_ARM)
-        #include <intrin.h>
-        #define YIELD() __yield()
-    #elif defined(__aarch64__) || (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7))
-        #if (__GNUC__ < 5)
-            #define YIELD() __asm__ volatile("yield" ::: "memory")
-        #else
-            #include <arm_acle.h>
-            #define YIELD() __yield()
-        #endif
-    #elif defined(__riscv)
+#if defined(__GNUC__) || defined(__clang__)
+    #if defined(__x86_64__) || defined(__i386__) || defined(__riscv)
         #define YIELD() __asm__ volatile("pause" ::: "memory")
+    #elif defined(__aarch64__) || (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7))
+        #define YIELD() __asm__ volatile("yield" ::: "memory")
+    #else
+        #define YIELD() ((void)0)
+    #endif
+#elif defined(_MSC_VER)
+    #include <intrin.h>
+    #if defined(_M_X64) || defined(_M_IX86)
+        #define YIELD() _mm_pause()
+    #elif defined(_M_ARM64) || defined(_M_ARM)
+        #define YIELD() __yield()
     #else
         #define YIELD() ((void)0)
     #endif

--- a/src/common.h
+++ b/src/common.h
@@ -36,26 +36,29 @@
     #endif
 #endif
 
-#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
-    #if defined(__GNUC__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 4))
-        #define YIELD() __asm__ volatile("rep; nop" ::: "memory")
-    #else
-        #include <immintrin.h>
-        #define YIELD() _mm_pause()
-    #endif
-#elif defined(_M_ARM64) || defined(_M_ARM)
-    #include <intrin.h>
-    #define YIELD() __yield()
-#elif defined(__aarch64__) || (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7))
-    #if defined(__GNUC__) && (__GNUC__ < 5)
-        #define YIELD() __asm__ volatile("yield" ::: "memory")
-    #else
-        #include <arm_acle.h>
+#ifdef __GNUC__
+    #if defined(__x86_64__) || defined(__i386__) || defined(_M_X64) || defined(_M_IX86)
+        #if defined(__GNUC__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && __GNUC_MINOR__ < 4))
+            #define YIELD() __asm__ volatile("rep; nop" ::: "memory")
+        #else
+            #include <immintrin.h>
+            #define YIELD() _mm_pause()
+        #endif
+    #elif defined(_M_ARM64) || defined(_M_ARM)
+        #include <intrin.h>
         #define YIELD() __yield()
+    #elif defined(__aarch64__) || (defined(__arm__) && defined(__ARM_ARCH) && (__ARM_ARCH >= 7))
+        #if defined(__GNUC__) && (__GNUC__ < 5)
+            #define YIELD() __asm__ volatile("yield" ::: "memory")
+        #else
+            #include <arm_acle.h>
+            #define YIELD() __yield()
+        #endif
+    #elif defined(__riscv)
+        #define YIELD() __asm__ volatile("pause" ::: "memory")
+    #else
+        #define YIELD() ((void)0)
     #endif
-#elif defined(__riscv)
-    #define YIELD() __asm__ volatile("pause" ::: "memory")
 #else
     #define YIELD() ((void)0)
 #endif
-

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -266,6 +266,7 @@ void platformSleepUntil(double time) {
         glfwSleep(remaining - 0.001);
 
     while (platformGetTime() < time) {
+        // Spin-wait for the remaining sub-millisecond
         YIELD();
     }
 }

--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -266,6 +266,6 @@ void platformSleepUntil(double time) {
         glfwSleep(remaining - 0.001);
 
     while (platformGetTime() < time) {
-        // Spin-wait for the remaining sub-millisecond
+        YIELD();
     }
 }

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -427,6 +427,7 @@ void platformSleepUntil(double time) {
 #endif
     }
     while (platformGetTime() < time) {
+        // Spin-wait for the remaining sub-millisecond
         YIELD();
     }
 }

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -427,6 +427,6 @@ void platformSleepUntil(double time) {
 #endif
     }
     while (platformGetTime() < time) {
-        // Spin-wait for the remaining sub-millisecond
+        YIELD();
     }
 }

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -257,6 +257,7 @@ void platformSleepUntil(double time) {
         SDL_Delay((Uint32)((remaining - 0.001) * 1000));
 
     while (platformGetTime() < time) {
+        // Spin-wait for the remaining sub-millisecond
         YIELD();
     }
 }

--- a/src/desktop/backends/sdl1.c
+++ b/src/desktop/backends/sdl1.c
@@ -257,6 +257,6 @@ void platformSleepUntil(double time) {
         SDL_Delay((Uint32)((remaining - 0.001) * 1000));
 
     while (platformGetTime() < time) {
-        // Spin-wait for the remaining sub-millisecond
+        YIELD();
     }
 }

--- a/src/desktop/backends/sdl2.c
+++ b/src/desktop/backends/sdl2.c
@@ -320,6 +320,7 @@ void platformSleepUntil(double time) {
         SDL_Delay((Uint32)((remaining - 0.001) * 1000));
 
     while (platformGetTime() < time) {
+        // Spin-wait for the remaining sub-millisecond
         YIELD();
     }
 }

--- a/src/desktop/backends/sdl2.c
+++ b/src/desktop/backends/sdl2.c
@@ -320,7 +320,7 @@ void platformSleepUntil(double time) {
         SDL_Delay((Uint32)((remaining - 0.001) * 1000));
 
     while (platformGetTime() < time) {
-        // Spin-wait for the remaining sub-millisecond
+        YIELD();
     }
 }
 


### PR DESCRIPTION
Supports x86, ARMv7+, RISC-V GCC/Clang/MSVC, otherwise falls back to a no-op.

Uses the pause/yield instruction to stop busy-looping from using CPU while waiting for the next frame to begin