### PR TITLE
fix little oversight when resetting to the default shader

### DIFF
--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -390,12 +390,6 @@ static void glInit(Renderer* renderer, DataWin* dataWin) {
     fprintf(stderr, "GL: Renderer initialized (%u texture pages)\n", gl->textureCount);
 }
 
-static void glGpuResetShader(Renderer* renderer) {
-    GLRenderer* gl = (GLRenderer*) renderer;
-    flushBatch(gl);
-    glUseProgram(gl->shaderProgram);
-    renderer->currentShader = -1;
-}
 
 static void glGpuSetShader(Renderer* renderer, int32_t ShaderIndex) {
     GLRenderer* gl = (GLRenderer*) renderer;
@@ -474,6 +468,13 @@ static void glShaderSettingsRefresh(Renderer* renderer) {
     }
 }
 
+static void glGpuResetShader(Renderer* renderer) {
+    GLRenderer* gl = (GLRenderer*) renderer;
+    flushBatch(gl);
+    glUseProgram(gl->shaderProgram);
+    renderer->currentShader = -1;
+    glShaderSettingsRefresh(renderer);
+}
 
 
 static void glDestroy(Renderer* renderer) {


### PR DESCRIPTION
I kinda forgor to make sure the uniforms get set if any were potentionally changed while using another shader and then switched back to the default shader, hope there weren't any bugs related to this and hope it doesn't add more bugs...