### PR TITLE
Fix hang on GLFW2

### DIFF
--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -292,7 +292,7 @@ bool platformHandleEvents(void) {
 }
 
 void platformSleepUntil(uint64_t time) {
-    double remaining = ((int64_t)time - nowNanos()) / 1000000000.0;
+    double remaining = ((int64_t)time - (int64_t)nowNanos()) / 1000000000.0;
     if (remaining > 0.002) // glfwSleep takes seconds as a double
         glfwSleep(remaining - 0.001);
 


### PR DESCRIPTION
The calculation would be an unsigned subtraction and wrap around, which results in sleeping basically forever.