### PR TITLE
Changed 2.2+ to 2.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Butterscotch supports the following WAD versions:
 * WAD Version 14 (GameMaker: Studio 1.4.1464+)
 * WAD Version 15 (GameMaker: Studio 1.4.1675+)
 * WAD Version 16 (GameMaker: Studio 1.4.1767+)
-* WAD Version 17 (GameMaker: Studio 2.2+)
+* WAD Version 17 (GameMaker: Studio 2.0+)
 
 Other modding tools, such as UndertaleModTool, calls it "bytecode version" instead of "WAD version". We decided to go with WAD version instead because there are GameMaker: Studio versions (WAD version 6 and 7) that DO NOT use bytecode altogether, so calling it "bytecode version" is not quite correct, and because that's what the YoYo Runner calls it under the hood.
 


### PR DESCRIPTION
Changed 2.2+ to 2.0+ because of the March 2019 demo being built on GameMaker: Studio 2.0.0.0. https://github.com/ButterscotchRunner/CompatibilityList/issues/126