### PR TITLE
fix clang warning in stb_vorbis

### DIFF
--- a/vendor/stb/vorbis/stb_vorbis.c
+++ b/vendor/stb/vorbis/stb_vorbis.c
@@ -1401,7 +1401,7 @@ static int set_file_offset(stb_vorbis *f, unsigned int loc)
    #endif
    f->eof = 0;
    if (USE_MEMORY(f)) {
-      if (f->stream_start + loc >= f->stream_end || f->stream_start + loc < f->stream_start) {
+      if (loc >= f->stream_len) {
          f->stream = f->stream_end;
          f->eof = 1;
          return 0;


### PR DESCRIPTION
taken from https://github.com/nothings/stb/pull/1746
Mostly relevant for the makefile build, which doesn't have an easy way to disable warnings on certain files.
This is also technically a bugfix, since the overflow check was getting optimized away before and now will work, but It was unlikely enough to be an issue that I doubt anyone will notice.