### PR TITLE
Remove all VLAs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(butterscotch C)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-add_compile_options(-Wall -Wextra)
+add_compile_options(-Wall -Wextra -Wvla)
 if(WERROR)
     add_compile_options(-Werror)
 endif()

--- a/src/audio/openal/al_audio_system.c
+++ b/src/audio/openal/al_audio_system.c
@@ -804,14 +804,15 @@ static void maSetChannelCount(MAYBE_UNUSED AudioSystem* audio, MAYBE_UNUSED int3
 static void maGroupLoad(AudioSystem* audio, int32_t groupIndex) {
     if (groupIndex > 0) {
         int sz = snprintf(nullptr, 0, "audiogroup%d.dat", groupIndex);
-        char buf[sz + 1];
-        snprintf(buf, sizeof(buf), "audiogroup%d.dat", groupIndex);
+        char *buf = (char *)safeMalloc(sz + 1);
+        snprintf(buf, sz + 1, "audiogroup%d.dat", groupIndex);
 
         // The original runner does not care if the file doesn't exist (this may happen if someone uses "audio_group_load" on a non-existent group)
         FileSystem* fileSystem = ((AlAudioSystem*)audio)->fileSystem;
         char* resolvedPath = (((AlAudioSystem*)audio)->fileSystem->vtable->resolvePath(((AlAudioSystem*)audio)->fileSystem, buf));
         if (!fileSystem->vtable->fileExists(fileSystem, resolvedPath)) {
             fprintf(stderr, "Audio: Wanted to load Audio Group %d, but Audio Group %d does not exist!\n", groupIndex, groupIndex);
+            free(buf);
             return;
         }
 
@@ -819,6 +820,7 @@ static void maGroupLoad(AudioSystem* audio, int32_t groupIndex) {
         options.parseAudo = true;
         DataWin *audioGroup = DataWin_parse(((AlAudioSystem*)audio)->fileSystem->vtable->resolvePath(((AlAudioSystem*)audio)->fileSystem, buf), options);
         arrput(audio->audioGroups, audioGroup);
+        free(buf);
     }
 }
 

--- a/src/vm.h
+++ b/src/vm.h
@@ -368,13 +368,23 @@ static inline bool VM_shouldTraceVariable(StringBooleanEntry* traceMap, const ch
     // "hp" should trace EVERY "hp" variable read/write to ALL objects
     if (shgeti(traceMap, varName) != -1) return true;
     // "obj_mainchara.hp" should trace EVERY variable read/write to the "hp" variable on the "obj_mainchara" object.
-    char formatted[strlen(scopeName) + 1 + strlen(varName) + 1];
-    snprintf(formatted, sizeof(formatted), "%s.%s", scopeName, varName);
-    if (shgeti(traceMap, formatted) != -1) return true;
+    size_t formattedSize = strlen(scopeName) + 1 + strlen(varName) + 1;
+    char *formatted = (char *)safeMalloc(formattedSize);
+    snprintf(formatted, formattedSize, "%s.%s", scopeName, varName);
+    if (shgeti(traceMap, formatted) != -1) {
+        free(formatted);
+        return true;
+    }
+    free(formatted);
     if (altScopeName != nullptr) {
-        char altFormatted[strlen(altScopeName) + 1 + strlen(varName) + 1];
-        snprintf(altFormatted, sizeof(altFormatted), "%s.%s", altScopeName, varName);
-        if (shgeti(traceMap, altFormatted) != -1) return true;
+        size_t altFormattedSize = strlen(altScopeName) + 1 + strlen(varName) + 1;
+        char *altFormatted = (char *)safeMalloc(altFormattedSize);
+        snprintf(altFormatted, altFormattedSize, "%s.%s", altScopeName, varName);
+        if (shgeti(traceMap, altFormatted) != -1) {
+            free(altFormatted);
+            return true;
+        }
+        free(altFormatted);
     }
     return false;
 }

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -1762,7 +1762,7 @@ static RValue builtin_string_length(MAYBE_UNUSED VMContext* ctx, RValue* args, i
 
 // https://docs.vultr.com/clang/examples/remove-all-characters-in-a-string-except-alphabets
 void filterAlphabets(char *str) {
-    char result[strlen(str) + 1];
+    char *result = (char *)safeMalloc(strlen(str) + 1);
     int j = 0;
     for (int i = 0; str[i] != '\0'; i++) {
         if ((str[i] >= 'a' && str[i] <= 'z') || (str[i] >= 'A' && str[i] <= 'Z')) {
@@ -1771,6 +1771,7 @@ void filterAlphabets(char *str) {
     }
     result[j] = '\0';  // Null-terminate the result string
     strcpy(str, result);  // Optionally copy back to original string
+    free(result);
 }
 
 static RValue builtin_string_letters(MAYBE_UNUSED VMContext* ctx, RValue* args, int32_t argCount) {


### PR DESCRIPTION
Removes all variable length arrays from the codebase
Predecessor to #245 
We shouldn't have VLAs anyway even if we don't care about C++ compatibility, there's no way to check if an allocation fails.