### PR TITLE
Use compatibility profile on GLFW

### DIFF
--- a/src/desktop/backends/glfw2.c
+++ b/src/desktop/backends/glfw2.c
@@ -31,6 +31,7 @@ static bool tryOpenWindow(int reqW, int reqH) {
         glfwOpenWindowHint(GLFW_OPENGL_VERSION_MINOR, GLCommon_versions[i].minor);
             
         if (GLCommon_versions[i].major >= 3) {
+            glfwOpenWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_COMPAT_PROFILE);
             if (GLCommon_versions[i].major == 3 && GLCommon_versions[i].minor == 2) {
                 glfwOpenWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
             } else {

--- a/src/desktop/backends/glfw3.c
+++ b/src/desktop/backends/glfw3.c
@@ -57,6 +57,7 @@ static GLFWwindow *tryOpenWindow(int reqW, int reqH, const char* title) {
             glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
         } else {
             glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
+            glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_COMPAT_PROFILE);
             if (GLCommon_versions[i].major >= 3) {
                 if (GLCommon_versions[i].major == 3 && GLCommon_versions[i].minor == 2) {
                     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);


### PR DESCRIPTION
This should fix macOS trying to create an OpenGL Core context on both GLFW frontends