### PR TITLE
gl_wrappers.h

### DIFF
--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -35,6 +35,7 @@
 #ifdef ENABLE_LEGACY_GL
 #include "gl_legacy_renderer.h"
 #endif
+#include "gl_wrappers.h"
 #endif
 #ifdef ENABLE_SW_RENDERER
 #include "sw_renderer.h"

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -67,56 +67,7 @@ static bool hasVAO() {
 #endif
 }
 
-#if !defined(__EMSCRIPTEN__)
-static void rt_glBindVertexArray(GLuint vao) {
-    if (glBindVertexArray) glBindVertexArray(vao);
-    else glBindVertexArrayOES(vao);
-}
-#undef glBindVertexArray
-#define glBindVertexArray rt_glBindVertexArray
-
-static void rt_glGenVertexArrays(GLsizei n, GLuint* arrays) {
-    if (glGenVertexArrays) glGenVertexArrays(n, arrays);
-    else glGenVertexArraysOES(n, arrays);
-}
-#undef glGenVertexArrays
-#define glGenVertexArrays rt_glGenVertexArrays
-
-static void rt_glDeleteVertexArrays(GLsizei n, const GLuint* arrays) {
-    if (glDeleteVertexArrays) glDeleteVertexArrays(n, arrays);
-    else glDeleteVertexArraysOES(n, arrays);
-}
-#undef glDeleteVertexArrays
-#define glDeleteVertexArrays rt_glDeleteVertexArrays
-
-static void rt_glGenFramebuffers(GLsizei n, GLuint* ids) {
-    if (glGenFramebuffers) glGenFramebuffers(n, ids);
-    else glGenFramebuffersEXT(n, ids);
-}
-#undef glGenFramebuffers
-#define glGenFramebuffers rt_glGenFramebuffers
-
-static void rt_glBindFramebuffer(GLenum target, GLuint fb) {
-    if (glBindFramebuffer) glBindFramebuffer(target, fb);
-    else glBindFramebufferEXT(target, fb);
-}
-#undef glBindFramebuffer
-#define glBindFramebuffer rt_glBindFramebuffer
-
-static void rt_glFramebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level) {
-    if (glFramebufferTexture2D) glFramebufferTexture2D(target, attachment, textarget, texture, level);
-    else glFramebufferTexture2DEXT(target, attachment, textarget, texture, level);
-}
-#undef glFramebufferTexture2D
-#define glFramebufferTexture2D rt_glFramebufferTexture2D
-
-static void rt_glDeleteFramebuffers(GLsizei n, const GLuint* ids) {
-    if (glDeleteFramebuffers) glDeleteFramebuffers(n, ids);
-    else glDeleteFramebuffersEXT(n, ids);
-}
-#undef glDeleteFramebuffers
-#define glDeleteFramebuffers rt_glDeleteFramebuffers
-#endif
+#include "gl_wrappers.h"
 
 // ===[ Shader Compilation ]===
 

--- a/src/gl_common/gl_common.c
+++ b/src/gl_common/gl_common.c
@@ -8,6 +8,8 @@
 #include "utils.h"
 #include "renderer.h" // for bm_* constants
 
+#include "gl_wrappers.h"
+
 // ===[ Letterbox blit ]===
 
 void GLCommon_computeLetterbox(int32_t gameW, int32_t gameH, int32_t windowW, int32_t windowH, int32_t* outStartX, int32_t* outStartY, int32_t* outEndX, int32_t* outEndY) {

--- a/src/gl_common/gl_wrappers.h
+++ b/src/gl_common/gl_wrappers.h
@@ -1,0 +1,53 @@
+#if !defined(_BS_GL_WRAPPERS_H_) && !defined(__EMSCRIPTEN__) && !defined(PLATFORM_PS3)
+#define _BS_GL_WRAPPERS_H_
+
+static inline void rt_glBindVertexArray(GLuint vao) {
+    if (glBindVertexArray) glBindVertexArray(vao);
+    else glBindVertexArrayOES(vao);
+}
+#undef glBindVertexArray
+#define glBindVertexArray rt_glBindVertexArray
+
+static inline void rt_glGenVertexArrays(GLsizei n, GLuint* arrays) {
+    if (glGenVertexArrays) glGenVertexArrays(n, arrays);
+    else glGenVertexArraysOES(n, arrays);
+}
+#undef glGenVertexArrays
+#define glGenVertexArrays rt_glGenVertexArrays
+
+static inline void rt_glDeleteVertexArrays(GLsizei n, const GLuint* arrays) {
+    if (glDeleteVertexArrays) glDeleteVertexArrays(n, arrays);
+    else glDeleteVertexArraysOES(n, arrays);
+}
+#undef glDeleteVertexArrays
+#define glDeleteVertexArrays rt_glDeleteVertexArrays
+
+static inline void rt_glGenFramebuffers(GLsizei n, GLuint* ids) {
+    if (glGenFramebuffers) glGenFramebuffers(n, ids);
+    else glGenFramebuffersEXT(n, ids);
+}
+#undef glGenFramebuffers
+#define glGenFramebuffers rt_glGenFramebuffers
+
+static inline void rt_glBindFramebuffer(GLenum target, GLuint fb) {
+    if (glBindFramebuffer) glBindFramebuffer(target, fb);
+    else glBindFramebufferEXT(target, fb);
+}
+#undef glBindFramebuffer
+#define glBindFramebuffer rt_glBindFramebuffer
+
+static inline void rt_glFramebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level) {
+    if (glFramebufferTexture2D) glFramebufferTexture2D(target, attachment, textarget, texture, level);
+    else glFramebufferTexture2DEXT(target, attachment, textarget, texture, level);
+}
+#undef glFramebufferTexture2D
+#define glFramebufferTexture2D rt_glFramebufferTexture2D
+
+static inline void rt_glDeleteFramebuffers(GLsizei n, const GLuint* ids) {
+    if (glDeleteFramebuffers) glDeleteFramebuffers(n, ids);
+    else glDeleteFramebuffersEXT(n, ids);
+}
+#undef glDeleteFramebuffers
+#define glDeleteFramebuffers rt_glDeleteFramebuffers
+
+#endif

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -53,35 +53,7 @@ static bool hasFBO() {
 #endif
 }
 
-#ifndef PLATFORM_PS3
-static void rt_glGenFramebuffers(GLsizei n, GLuint* ids) {
-    if (glGenFramebuffers) glGenFramebuffers(n, ids);
-    else glGenFramebuffersEXT(n, ids);
-}
-#undef glGenFramebuffers
-#define glGenFramebuffers rt_glGenFramebuffers
-
-static void rt_glBindFramebuffer(GLenum target, GLuint fb) {
-    if (glBindFramebuffer) glBindFramebuffer(target, fb);
-    else glBindFramebufferEXT(target, fb);
-}
-#undef glBindFramebuffer
-#define glBindFramebuffer rt_glBindFramebuffer
-
-static void rt_glFramebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level) {
-    if (glFramebufferTexture2D) glFramebufferTexture2D(target, attachment, textarget, texture, level);
-    else glFramebufferTexture2DEXT(target, attachment, textarget, texture, level);
-}
-#undef glFramebufferTexture2D
-#define glFramebufferTexture2D rt_glFramebufferTexture2D
-
-static void rt_glDeleteFramebuffers(GLsizei n, const GLuint* ids) {
-    if (glDeleteFramebuffers) glDeleteFramebuffers(n, ids);
-    else glDeleteFramebuffersEXT(n, ids);
-}
-#undef glDeleteFramebuffers
-#define glDeleteFramebuffers rt_glDeleteFramebuffers
-#endif
+#include "gl_wrappers.h"
 
 // ===[ Helpers ]===
 


### PR DESCRIPTION
Moves all those wrapper function things into their own header.
Reduces code duplication in gl_legacy_renderer.c
Also fixes stuff like glBindFramebuffer being called unconditionally in gl_common.c and desktop/main.c.