### PR TITLE
Apply an offset to certain primitives just like GameMaker runner does

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -2426,10 +2426,7 @@ void Runner_initFirstRoom(Runner* runner) {
 
     // GameMaker Studio (as of 2024.14) applies an offset of 1 virtual pixel to certain
     // primitives if this flag isn't set.
-    runner->applyOffsetForPrimitives = true;
-    if (dataWin->optn.info & 0x800000000LL) {
-        runner->applyOffsetForPrimitives = false;
-    }
+    runner->applyOffsetForPrimitives = !(dataWin->optn.info & 0x800000000LL);
 
     // Run global init scripts with the global scope instance as "self"
     // In GMS 2.3+ (BC17), GLOB scripts store function declarations on "self" via Pop.v.v

--- a/src/runner.c
+++ b/src/runner.c
@@ -2425,8 +2425,9 @@ void Runner_initFirstRoom(Runner* runner) {
     runner->gameStartTime = nowNanos();
 
     // GameMaker Studio (as of 2024.14) applies an offset of 1 virtual pixel to certain
-    // primitives if this flag isn't set.
-    runner->applyOffsetForPrimitives = !(dataWin->optn.info & 0x800000000LL);
+    // primitives if bit 35 is set.  Earlier versions of GameMaker or GameMaker Studio
+    // appear to apply it unconditionally.
+    runner->applyOffsetForPrimitives = !DataWin_isVersionAtLeast(dataWin, 2024, 14, 0, 0) || ((dataWin->optn.info >> 35) & 1);
 
     // Run global init scripts with the global scope instance as "self"
     // In GMS 2.3+ (BC17), GLOB scripts store function declarations on "self" via Pop.v.v

--- a/src/runner.c
+++ b/src/runner.c
@@ -2424,6 +2424,13 @@ void Runner_initFirstRoom(Runner* runner) {
 
     runner->gameStartTime = nowNanos();
 
+    // GameMaker Studio (as of 2024.14) applies an offset of 1 virtual pixel to certain
+    // primitives if this flag isn't set.
+    runner->applyOffsetForPrimitives = true;
+    if (dataWin->optn.info & 0x800000000LL) {
+        runner->applyOffsetForPrimitives = false;
+    }
+
     // Run global init scripts with the global scope instance as "self"
     // In GMS 2.3+ (BC17), GLOB scripts store function declarations on "self" via Pop.v.v
     runner->vmContext->currentInstance = runner->vmContext->globalScopeInstance;

--- a/src/runner.h
+++ b/src/runner.h
@@ -517,6 +517,7 @@ struct Runner {
     struct { char* key; int value; }* disabledObjects; // stb_ds string hashmap, nullptr = no filtering
     struct { int key; Instance* value; }* instancesById;
     bool forceDrawDepth;
+    bool applyOffsetForPrimitives;
     // Depth-sorted unified list of all drawables (instances + tiles + runtime layers) for the current room.
     // Active/visible filtering happens at draw time, so toggling those flags does not invalidate the cache.
     //

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -9675,6 +9675,10 @@ static RValue builtin_draw_rectangle(VMContext* ctx, RValue* args, MAYBE_UNUSED 
     float x2 = (float) RValue_toReal(args[2]);
     float y2 = (float) RValue_toReal(args[3]);
     bool outline = RValue_toBool(args[4]);
+    if (runner->applyOffsetForPrimitives) {
+        x1 += 1.0f; y1 += 1.0f;
+        x2 += 1.0f; y2 += 1.0f;
+    }
     runner->renderer->vtable->drawRectangle(runner->renderer, x1, y1, x2, y2, runner->renderer->drawColor, runner->renderer->drawAlpha, outline);
     return RValue_makeUndefined();
 }
@@ -9692,6 +9696,11 @@ static RValue builtin_draw_rectangle_color(VMContext* ctx, RValue* args, MAYBE_U
     uint32_t color3 = (uint32_t) RValue_toInt32(args[6]);
     uint32_t color4 = (uint32_t) RValue_toInt32(args[7]);
     bool outline = RValue_toBool(args[8]);
+
+    if (runner->applyOffsetForPrimitives) {
+        x1 += 1.0f; y1 += 1.0f;
+        x2 += 1.0f; y2 += 1.0f;
+    }
 
     runner->renderer->vtable->drawRectangleColor(runner->renderer, x1, y1, x2, y2, color1, color2, color3, color4, runner->renderer->drawAlpha, outline);
     return RValue_makeUndefined();
@@ -10142,6 +10151,10 @@ static RValue builtin_draw_line(VMContext* ctx, RValue* args, MAYBE_UNUSED int32
         float y1 = (float) RValue_toReal(args[1]);
         float x2 = (float) RValue_toReal(args[2]);
         float y2 = (float) RValue_toReal(args[3]);
+        if (runner->applyOffsetForPrimitives) {
+            x1 += 1.0f; y1 += 1.0f;
+            x2 += 1.0f; y2 += 1.0f;
+        }
         runner->renderer->vtable->drawLine(runner->renderer, x1, y1, x2, y2, 1.0f, runner->renderer->drawColor, runner->renderer->drawAlpha);
     }
     return RValue_makeUndefined();
@@ -10157,6 +10170,10 @@ static RValue builtin_draw_line_colour(VMContext* ctx, RValue* args, MAYBE_UNUSE
         float y2 = (float) RValue_toReal(args[3]);
         float col1 = (float) RValue_toReal(args[4]);
         float col2 = (float) RValue_toReal(args[5]);
+        if (runner->applyOffsetForPrimitives) {
+            x1 += 1.0f; y1 += 1.0f;
+            x2 += 1.0f; y2 += 1.0f;
+        }
         runner->renderer->vtable->drawLineColor(runner->renderer, x1, y1, x2, y2, 1.0f, col1, col2, runner->renderer->drawAlpha);
     }
     return RValue_makeUndefined();
@@ -10171,6 +10188,10 @@ static RValue builtin_draw_line_width(VMContext* ctx, RValue* args, MAYBE_UNUSED
         float x2 = (float) RValue_toReal(args[2]);
         float y2 = (float) RValue_toReal(args[3]);
         float w = (float) RValue_toReal(args[4]);
+        if (runner->applyOffsetForPrimitives) {
+            x1 += 1.0f; y1 += 1.0f;
+            x2 += 1.0f; y2 += 1.0f;
+        }
         runner->renderer->vtable->drawLine(runner->renderer, x1, y1, x2, y2, w, runner->renderer->drawColor, runner->renderer->drawAlpha);
     }
     return RValue_makeUndefined();
@@ -10187,6 +10208,10 @@ static RValue builtin_draw_line_width_colour(VMContext* ctx, RValue* args, MAYBE
         float w = (float) RValue_toReal(args[4]);
         uint32_t col1 = (uint32_t) RValue_toInt32(args[5]);
         uint32_t col2 = (uint32_t) RValue_toInt32(args[6]);
+        if (runner->applyOffsetForPrimitives) {
+            x1 += 1.0f; y1 += 1.0f;
+            x2 += 1.0f; y2 += 1.0f;
+        }
         runner->renderer->vtable->drawLineColor(runner->renderer, x1, y1, x2, y2, w, col1, col2, runner->renderer->drawAlpha);
     }
     return RValue_makeUndefined();
@@ -10204,6 +10229,11 @@ static RValue builtin_draw_triangle(VMContext* ctx, RValue* args, MAYBE_UNUSED i
         float y3 = (float) RValue_toReal(args[5]);
         bool outline = (float) RValue_toBool(args[6]);
         uint32_t color = runner->renderer->drawColor;
+        if (runner->applyOffsetForPrimitives) {
+            x1 += 1.0f; y1 += 1.0f;
+            x2 += 1.0f; y2 += 1.0f;
+            x3 += 1.0f; y3 += 1.0f;
+        }
         runner->renderer->vtable->drawTriangle(runner->renderer, x1, y1, x2, y2, x3, y3, color, color, color, runner->renderer->drawAlpha, outline);
     }
     return RValue_makeUndefined();
@@ -10223,6 +10253,11 @@ static RValue builtin_draw_triangle_color(VMContext* ctx, RValue* args, MAYBE_UN
         uint32_t col2 = (uint32_t) RValue_toInt32(args[7]);
         uint32_t col3 = (uint32_t) RValue_toInt32(args[8]);
         bool outline = RValue_toBool(args[9]);
+        if (runner->applyOffsetForPrimitives) {
+            x1 += 1.0f; y1 += 1.0f;
+            x2 += 1.0f; y2 += 1.0f;
+            x3 += 1.0f; y3 += 1.0f;
+        }
         runner->renderer->vtable->drawTriangle(runner->renderer, x1, y1, x2, y2, x3, y3, col1, col2, col3, runner->renderer->drawAlpha, outline);
     }
     return RValue_makeUndefined();
@@ -10236,6 +10271,9 @@ static RValue builtin_draw_circle(VMContext* ctx, RValue* args, MAYBE_UNUSED int
         float y = (float) RValue_toReal(args[1]);
         float r = (float) RValue_toReal(args[2]);
         bool outline = RValue_toBool(args[3]);
+        if (runner->applyOffsetForPrimitives) {
+            x += 1.0f; y += 1.0f;
+        }
         Renderer_drawCircle(runner->renderer, x, y, r, outline);
     }
     return RValue_makeUndefined();
@@ -10266,6 +10304,10 @@ static RValue builtin_draw_ellipse(VMContext* ctx, RValue* args, MAYBE_UNUSED in
         float y2 = (float) RValue_toReal(args[3]);
         bool outline = RValue_toBool(args[4]);
         uint32_t color = runner->renderer->drawColor;
+        if (runner->applyOffsetForPrimitives) {
+            x1 += 1.0f; y1 += 1.0f;
+            x2 += 1.0f; y2 += 1.0f;
+        }
         Renderer_drawEllipseColor(runner->renderer, (x1 + x2) * 0.5f, (y1 + y2) * 0.5f, (x2 - x1) * 0.5f, (y2 - y1) * 0.5f, color, color, outline);
     }
     return RValue_makeUndefined();
@@ -10282,6 +10324,10 @@ static RValue builtin_draw_ellipse_color(VMContext* ctx, RValue* args, MAYBE_UNU
         uint32_t col1 = (uint32_t) RValue_toInt32(args[4]);
         uint32_t col2 = (uint32_t) RValue_toInt32(args[5]);
         bool outline = RValue_toBool(args[6]);
+        if (runner->applyOffsetForPrimitives) {
+            x1 += 1.0f; y1 += 1.0f;
+            x2 += 1.0f; y2 += 1.0f;
+        }
         Renderer_drawEllipseColor(runner->renderer, (x1 + x2) * 0.5f, (y1 + y2) * 0.5f, (x2 - x1) * 0.5f, (y2 - y1) * 0.5f, col1, col2, outline);
     }
     return RValue_makeUndefined();

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -9676,8 +9676,9 @@ static RValue builtin_draw_rectangle(VMContext* ctx, RValue* args, MAYBE_UNUSED 
     float y2 = (float) RValue_toReal(args[3]);
     bool outline = RValue_toBool(args[4]);
     if (runner->applyOffsetForPrimitives) {
-        x1 += 1.0f; y1 += 1.0f;
         x2 += 1.0f; y2 += 1.0f;
+        if (x2 == floorf(x2)) x2 += 0.01f;
+        if (y2 == floorf(x2)) y2 += 0.01f;
     }
     runner->renderer->vtable->drawRectangle(runner->renderer, x1, y1, x2, y2, runner->renderer->drawColor, runner->renderer->drawAlpha, outline);
     return RValue_makeUndefined();
@@ -9696,12 +9697,11 @@ static RValue builtin_draw_rectangle_color(VMContext* ctx, RValue* args, MAYBE_U
     uint32_t color3 = (uint32_t) RValue_toInt32(args[6]);
     uint32_t color4 = (uint32_t) RValue_toInt32(args[7]);
     bool outline = RValue_toBool(args[8]);
-
     if (runner->applyOffsetForPrimitives) {
-        x1 += 1.0f; y1 += 1.0f;
         x2 += 1.0f; y2 += 1.0f;
+        if (x2 == floorf(x2)) x2 += 0.01f;
+        if (y2 == floorf(x2)) y2 += 0.01f;
     }
-
     runner->renderer->vtable->drawRectangleColor(runner->renderer, x1, y1, x2, y2, color1, color2, color3, color4, runner->renderer->drawAlpha, outline);
     return RValue_makeUndefined();
 }


### PR DESCRIPTION
Controlled by a flag, because some GameMaker games don't actually need this fix applied.

This fixes the gears in the Core in UNDERTALE and makes them look correct.