### PR TITLE
stbi config

### DIFF
--- a/src/android/stb_impl.c
+++ b/src/android/stb_impl.c
@@ -1,4 +1,5 @@
 #define STB_IMAGE_IMPLEMENTATION
+#define STBI_NO_STDIO
 #include "stb_image.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION

--- a/src/desktop/stb_impl.c
+++ b/src/desktop/stb_impl.c
@@ -1,4 +1,5 @@
 #define STB_IMAGE_IMPLEMENTATION
+#define STBI_NO_STDIO
 #include "stb_image.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION

--- a/src/ps3/stb_impl.c
+++ b/src/ps3/stb_impl.c
@@ -1,4 +1,5 @@
 #define STB_IMAGE_IMPLEMENTATION
+#define STBI_NO_STDIO
 #include "stb_image.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION

--- a/src/web/stb_impl.c
+++ b/src/web/stb_impl.c
@@ -1,4 +1,5 @@
 #define STB_IMAGE_IMPLEMENTATION
+#define STBI_NO_STDIO
 #include "stb_image.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION

--- a/vendor/stb/image/stb_image.h
+++ b/vendor/stb/image/stb_image.h
@@ -777,6 +777,10 @@ static int stbi__sse2_available(void)
 #endif
 #endif
 
+#ifdef __ARM_NEON__
+#define STBI_NEON
+#endif
+
 // ARM NEON
 #if defined(STBI_NO_SIMD) && defined(STBI_NEON)
 #undef STBI_NEON


### PR DESCRIPTION
defining STBI_NO_STDIO is a very small but totally free improvement in binary size, a little less than 700 bytes on glfw3 linux x86_64.  Comes from excluding code to parse images from FILE*, but we always pass raw memory buffers and never use those functions, so they're useless to us.

The STBI_NEON thing just enables SIMD instructions on armv7 and arm64 automatically.