### PR TITLE
memory usage info on backspace + free blobData after we're done with it

### DIFF
--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -74,7 +74,7 @@ const GLuint *hostFramebuffer;
 #include <unistd.h>
 #endif
 
-size_t get_anon_rss_bytes(void) {
+static size_t get_anon_rss_bytes(void) {
 #ifdef __linux__
     int fd = open("/proc/self/smaps_rollup", O_RDONLY);
     if (fd < 0)

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -1752,6 +1752,12 @@ int main(int argc, char* argv[]) {
                 Runner_handlePendingRoomChange(runner);
             }
 
+#ifdef HAVE_MALLINFO2
+            if (RunnerKeyboard_checkPressed(runner->keyboard, VK_BACKSPACE)) {
+                struct mallinfo2 mi = mallinfo2();
+                fprintf(stderr, "Memory use right now: %zu bytes (%.1f MB)\n", mi.uordblks, mi.uordblks / 1024.0f / 1024.0f);
+            }
+#endif
             // Limit frame rate to room speed (skip in headless mode for max speed!!)
             if (!args.headless && runner->currentRoom->speed > 0) {
                 static bool fastForwardActive = false;

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -1043,7 +1043,10 @@ int main(int argc, char* argv[]) {
         options.parseFunc = true;
         options.parseStrg = true;
         options.parseTxtr = true;
-        options.parseAudo = true;
+#if defined(USE_MINIAUDIO) || defined(USE_OPENAL)
+        if (!args.headless)
+            options.parseAudo = true;
+#endif
         options.skipLoadingPreciseMasksForNonPreciseSprites = true;
         options.loadType = args.loadType;
         options.lazyLoadRooms = args.lazyRooms;

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -74,7 +74,7 @@ const GLuint *hostFramebuffer;
 #include <unistd.h>
 #endif
 
-static size_t get_anon_rss_bytes(void) {
+static size_t get_used_memory(void) {
 #ifdef __linux__
     int fd = open("/proc/self/smaps_rollup", O_RDONLY);
     if (fd < 0)
@@ -1791,7 +1791,7 @@ int main(int argc, char* argv[]) {
             }
 
             if (RunnerKeyboard_checkPressed(runner->keyboard, VK_BACKSPACE)) {
-                size_t bytes_used = get_anon_rss_bytes();
+                size_t bytes_used = get_used_memory();
                 if (bytes_used == 0)
                     fprintf(stderr, "Unable to get memory usage\n");
                 else

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -69,6 +69,44 @@ enum GraphicsAPI gfx;
 const GLuint *hostFramebuffer;
 #endif
 
+#ifdef __linux__
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+size_t get_anon_rss_bytes(void) {
+#ifdef __linux__
+    int fd = open("/proc/self/smaps_rollup", O_RDONLY);
+    if (fd < 0)
+        return 0;
+
+    char buf[512];
+    int n = read(fd, buf, sizeof(buf) - 1);
+    close(fd);
+    if (n <= 0)
+        return 0;
+    buf[n] = '\0';
+
+    char *p = buf;
+    while (*p) {
+        if (strncmp(p, "Anonymous:", 10) == 0) {
+            p += 10;
+            while (*p == ' ' || *p == '\t')
+                p++;
+            size_t kb = 0;
+            while (*p >= '0' && *p <= '9')
+                kb = kb * 10 + (size_t)(*p++ - '0');
+            return kb * 1024;
+        }
+        while (*p && *p != '\n')
+            p++;
+        if (*p)
+            p++;
+    }
+#endif
+    return 0;
+}
+
 #if defined(ENABLE_LEGACY_GL) || defined(ENABLE_MODERN_GL) || ((defined(USE_GLFW3) || defined(USE_GLFW2)) && defined(ENABLE_SW_RENDERER))
 static int platformInitGlad(GLADloadproc load) {
     glGetString = (PFNGLGETSTRINGPROC)load("glGetString");
@@ -1752,12 +1790,14 @@ int main(int argc, char* argv[]) {
                 Runner_handlePendingRoomChange(runner);
             }
 
-#ifdef HAVE_MALLINFO2
             if (RunnerKeyboard_checkPressed(runner->keyboard, VK_BACKSPACE)) {
-                struct mallinfo2 mi = mallinfo2();
-                fprintf(stderr, "Memory use right now: %zu bytes (%.1f MB)\n", mi.uordblks, mi.uordblks / 1024.0f / 1024.0f);
+                size_t bytes_used = get_anon_rss_bytes();
+                if (bytes_used == 0)
+                    fprintf(stderr, "Unable to get memory usage\n");
+                else
+                    fprintf(stderr, "Memory use right now: %zu bytes (%.1f MB)\n", bytes_used, bytes_used / 1024.0f / 1024.0f);
             }
-#endif
+
             // Limit frame rate to room speed (skip in headless mode for max speed!!)
             if (!args.headless && runner->currentRoom->speed > 0) {
                 static bool fastForwardActive = false;

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -810,12 +810,17 @@ bool GLRenderer_ensureTextureLoaded(GLRenderer* gl, uint32_t pageId) {
         fprintf(stderr, "GL: Failed to decode TXTR page %u\n", pageId);
         return false;
     }
+    free(txtr->blobData);
+    txtr->blobData = nullptr;
 
     gl->textureWidths[pageId] = w;
     gl->textureHeights[pageId] = h;
 
     glBindTexture(GL_TEXTURE_2D, gl->glTextures[pageId]);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+
+    free(pixels);
+
     bool isPOT = (w & (w - 1)) == 0 && (h & (h - 1)) == 0;
     GLint wrapMode = isPOT ? GL_REPEAT : GL_CLAMP_TO_EDGE;
 
@@ -824,7 +829,6 @@ bool GLRenderer_ensureTextureLoaded(GLRenderer* gl, uint32_t pageId) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapMode);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapMode);
 
-    free(pixels);
     fprintf(stderr, "GL: Loaded TXTR page %u (%dx%d)\n", pageId, w, h);
     return true;
 }

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -329,18 +329,21 @@ bool GLLegacyRenderer_ensureTextureLoaded(GLLegacyRenderer* gl, uint32_t pageId)
         fprintf(stderr, "GL: Failed to decode TXTR page %u\n", pageId);
         return false;
     }
+    free(txtr->blobData);
+    txtr->blobData = nullptr;
 
     gl->textureWidths[pageId] = w;
     gl->textureHeights[pageId] = h;
 
     glBindTexture(GL_TEXTURE_2D, gl->glTextures[pageId]);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+
+    free(pixels);
+
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-
-    free(pixels);
 #endif
     fprintf(stderr, "GL: Loaded TXTR page %u (%dx%d)\n", pageId, w, h);
     return true;


### PR DESCRIPTION
At some point we should add a proper debug overlay to desktop/modern-gl, and we can put memory usage info in that
memory usage only works on Linux for now