### PR TITLE
Allocate room stuff in 1 block to reduce heap fragmentation

### DIFF
--- a/src/data_win.c
+++ b/src/data_win.c
@@ -1500,7 +1500,6 @@ static void parseOBJT(BinaryReader* reader, DataWin* dw) {
 static void readRoomBackgrounds(BinaryReader* reader, Room* room) {
     uint32_t bgCount;
     uint32_t* bgPtrs = readPointerTable(reader, &bgCount);
-    room->backgrounds = (RoomBackground *)safeMalloc(8 * sizeof(RoomBackground));
     uint32_t fillEnd = bgCount < 8 ? bgCount : 8;
     for (uint32_t j = 0; fillEnd > j; j++) {
         BinaryReader_seek(reader, bgPtrs[j]);
@@ -1525,7 +1524,6 @@ static void readRoomBackgrounds(BinaryReader* reader, Room* room) {
 static void readRoomViews(BinaryReader* reader, Room* room) {
     uint32_t viewCount;
     uint32_t* viewPtrsArr = readPointerTable(reader, &viewCount);
-    room->views = (RoomView *)safeMalloc(8 * sizeof(RoomView));
     for (uint32_t j = 0; viewCount > j && 8 > j; j++) {
         BinaryReader_seek(reader, viewPtrsArr[j]);
         RoomView* view = &room->views[j];
@@ -1550,39 +1548,32 @@ static void readRoomViews(BinaryReader* reader, Room* room) {
     free(viewPtrsArr);
 }
 
-static void readRoomGameObjects(BinaryReader* reader, DataWin* dw, Room* room) {
-    uint32_t objCount;
-    uint32_t* objPtrs = readPointerTable(reader, &objCount);
-    room->gameObjectCount = objCount;
-    if (objCount > 0) {
-        room->gameObjects = (RoomGameObject *)safeMalloc(objCount * sizeof(RoomGameObject));
-        repeat(objCount, j) {
-            BinaryReader_seek(reader, objPtrs[j]);
-            RoomGameObject* go = &room->gameObjects[j];
-            go->x = BinaryReader_readInt32(reader);
-            go->y = BinaryReader_readInt32(reader);
-            go->objectDefinition = BinaryReader_readInt32(reader);
-            go->instanceID = BinaryReader_readUint32(reader);
-            go->creationCode = BinaryReader_readInt32(reader);
-            go->scaleX = BinaryReader_readFloat32(reader);
-            go->scaleY = BinaryReader_readFloat32(reader);
-            if (DataWin_isVersionAtLeast(dw, 2, 2, 2, 302)) {
-                go->imageSpeed = BinaryReader_readFloat32(reader);
-                go->imageIndex = BinaryReader_readInt32(reader);
-            } else {
-                go->imageSpeed = 1.0f;
-                go->imageIndex = 0;
-            }
-            go->color = BinaryReader_readUint32(reader);
-            go->rotation = BinaryReader_readFloat32(reader);
-            if (dw->gen8.wadVersion >= 16) {
-                go->preCreateCode = BinaryReader_readInt32(reader);
-            } else {
-                go->preCreateCode = -1;
-            }
+static void readRoomGameObjects(BinaryReader* reader, DataWin* dw, Room* room, uint32_t* objPtrs) {
+    uint32_t objCount = room->gameObjectCount;
+    repeat(objCount, j) {
+        BinaryReader_seek(reader, objPtrs[j]);
+        RoomGameObject* go = &room->gameObjects[j];
+        go->x = BinaryReader_readInt32(reader);
+        go->y = BinaryReader_readInt32(reader);
+        go->objectDefinition = BinaryReader_readInt32(reader);
+        go->instanceID = BinaryReader_readUint32(reader);
+        go->creationCode = BinaryReader_readInt32(reader);
+        go->scaleX = BinaryReader_readFloat32(reader);
+        go->scaleY = BinaryReader_readFloat32(reader);
+        if (DataWin_isVersionAtLeast(dw, 2, 2, 2, 302)) {
+            go->imageSpeed = BinaryReader_readFloat32(reader);
+            go->imageIndex = BinaryReader_readInt32(reader);
+        } else {
+            go->imageSpeed = 1.0f;
+            go->imageIndex = 0;
         }
-    } else {
-        room->gameObjects = nullptr;
+        go->color = BinaryReader_readUint32(reader);
+        go->rotation = BinaryReader_readFloat32(reader);
+        if (dw->gen8.wadVersion >= 16) {
+            go->preCreateCode = BinaryReader_readInt32(reader);
+        } else {
+            go->preCreateCode = -1;
+        }
     }
     free(objPtrs);
 }
@@ -1593,32 +1584,25 @@ static float tileAlphaFromColor(uint32_t color) {
     return alphaByte == 0 ? 1.0f : (float) alphaByte / 255.0f;
 }
 
-static void readRoomTiles(BinaryReader* reader, DataWin* dw, Room* room) {
-    uint32_t tileCount;
-    uint32_t* tilePtrs = readPointerTable(reader, &tileCount);
-    room->tileCount = tileCount;
-    if (tileCount > 0) {
-        room->tiles = (RoomTile *)safeMalloc(tileCount * sizeof(RoomTile));
-        repeat(tileCount, j) {
-            BinaryReader_seek(reader, tilePtrs[j]);
-            RoomTile* tile = &room->tiles[j];
-            tile->x = BinaryReader_readInt32(reader);
-            tile->y = BinaryReader_readInt32(reader);
-            tile->useSpriteDefinition = DataWin_isVersionAtLeast(dw, 2, 0, 0, 0);
-            tile->backgroundDefinition = BinaryReader_readInt32(reader);
-            tile->sourceX = BinaryReader_readInt32(reader);
-            tile->sourceY = BinaryReader_readInt32(reader);
-            tile->width = BinaryReader_readUint32(reader);
-            tile->height = BinaryReader_readUint32(reader);
-            tile->tileDepth = BinaryReader_readInt32(reader);
-            tile->instanceID = BinaryReader_readUint32(reader);
-            tile->scaleX = BinaryReader_readFloat32(reader);
-            tile->scaleY = BinaryReader_readFloat32(reader);
-            tile->color = BinaryReader_readUint32(reader);
-            tile->alpha = tileAlphaFromColor(tile->color);
-        }
-    } else {
-        room->tiles = nullptr;
+static void readRoomTiles(BinaryReader* reader, DataWin* dw, Room* room, uint32_t* tilePtrs) {
+    uint32_t tileCount = room->tileCount;
+    repeat(tileCount, j) {
+        BinaryReader_seek(reader, tilePtrs[j]);
+        RoomTile* tile = &room->tiles[j];
+        tile->x = BinaryReader_readInt32(reader);
+        tile->y = BinaryReader_readInt32(reader);
+        tile->useSpriteDefinition = DataWin_isVersionAtLeast(dw, 2, 0, 0, 0);
+        tile->backgroundDefinition = BinaryReader_readInt32(reader);
+        tile->sourceX = BinaryReader_readInt32(reader);
+        tile->sourceY = BinaryReader_readInt32(reader);
+        tile->width = BinaryReader_readUint32(reader);
+        tile->height = BinaryReader_readUint32(reader);
+        tile->tileDepth = BinaryReader_readInt32(reader);
+        tile->instanceID = BinaryReader_readUint32(reader);
+        tile->scaleX = BinaryReader_readFloat32(reader);
+        tile->scaleY = BinaryReader_readFloat32(reader);
+        tile->color = BinaryReader_readUint32(reader);
+        tile->alpha = tileAlphaFromColor(tile->color);
     }
     free(tilePtrs);
 }
@@ -1830,17 +1814,48 @@ static void readRoomLayers(BinaryReader* reader, DataWin* dw, Room* room) {
 static void readRoomPayload(BinaryReader* reader, DataWin* dw, Room* room) {
     require(!room->payloadLoaded);
 
+    // allocate all the things at once to reduce heap fragmentation
+    BinaryReader_seek(reader, room->gameObjectsFileOffset);
+    uint32_t objCount;
+    uint32_t* objPtrs = readPointerTable(reader, &objCount);
+    room->gameObjectCount = objCount;
+
+    BinaryReader_seek(reader, room->tilesFileOffset);
+    uint32_t tileCount;
+    uint32_t* tilePtrs = readPointerTable(reader, &tileCount);
+    room->tileCount = tileCount;
+
+    char *ptr = (char *)safeMalloc(
+        (8 * sizeof(RoomBackground)) +
+        (8 * sizeof(RoomView)) +
+        (objCount * sizeof(RoomGameObject)) +
+        (tileCount * sizeof(RoomTile))
+    );
+    room->backgrounds = (RoomBackground *)ptr;
+    ptr += (8 * sizeof(RoomBackground));
+    room->views = (RoomView *)ptr;
+    ptr += (8 * sizeof(RoomView));
+    if (objCount > 0)
+        room->gameObjects = (RoomGameObject *)ptr;
+    else
+        room->gameObjects = nullptr;
+    ptr += (objCount * sizeof(RoomGameObject));
+    if (tileCount > 0)
+        room->tiles = (RoomTile *)ptr;
+    else
+        room->tiles = nullptr;
+
     BinaryReader_seek(reader, room->backgroundsFileOffset);
     readRoomBackgrounds(reader, room);
 
     BinaryReader_seek(reader, room->viewsFileOffset);
     readRoomViews(reader, room);
 
-    BinaryReader_seek(reader, room->gameObjectsFileOffset);
-    readRoomGameObjects(reader, dw, room);
+    BinaryReader_seek(reader, room->gameObjectsFileOffset + (sizeof(uint32_t) * (objCount + 1)));
+    readRoomGameObjects(reader, dw, room, objPtrs);
 
-    BinaryReader_seek(reader, room->tilesFileOffset);
-    readRoomTiles(reader, dw, room);
+    BinaryReader_seek(reader, room->tilesFileOffset + (sizeof(uint32_t) * (tileCount + 1)));
+    readRoomTiles(reader, dw, room, tilePtrs);
 
     room->layerCount = 0;
     room->layers = nullptr;
@@ -3001,12 +3016,9 @@ void DataWin_freeRoomPayload(Room* room) {
     requireNotNull(room);
     free(room->backgrounds);
     room->backgrounds = nullptr;
-    free(room->views);
     room->views = nullptr;
-    free(room->gameObjects);
     room->gameObjects = nullptr;
     room->gameObjectCount = 0;
-    free(room->tiles);
     room->tiles = nullptr;
     room->tileCount = 0;
     if (room->layerCount != 0 && room->layers != nullptr) {

--- a/src/data_win.c
+++ b/src/data_win.c
@@ -1622,9 +1622,6 @@ static void readRoomLayers(BinaryReader* reader, DataWin* dw, Room* room, uint32
         layer->hSpeed = BinaryReader_readFloat32(reader);
         layer->vSpeed = BinaryReader_readFloat32(reader);
         layer->visible = BinaryReader_readBool32(reader);
-        layer->assetsData = nullptr;
-        layer->backgroundData = nullptr;
-        layer->instancesData = nullptr;
         layer->tilesData = nullptr;
         if (DataWin_isVersionAtLeast(dw, 2022, 1, 0, 0)) {
             // EffectEnabled (bool32), EffectType (string ptr), EffectProperties (SimpleList<EffectProperty>)
@@ -3030,19 +3027,23 @@ void DataWin_freeRoomPayload(Room* room) {
     if (room->layerCount != 0 && room->layers != nullptr) {
         repeat(room->layerCount, j) {
             RoomLayer* layer = &room->layers[j];
-            if (layer->assetsData) {
-                free(layer->assetsData->legacyTiles);
-                free(layer->assetsData->sprites);
-                free(layer->assetsData);
-            }
-            if (layer->backgroundData) free(layer->backgroundData);
-            if (layer->instancesData) {
-                free(layer->instancesData->instanceIds);
-                free(layer->instancesData);
-            }
-            if (layer->tilesData) {
-                free(layer->tilesData->tileData);
-                free(layer->tilesData);
+            switch (layer->type) {
+                case RoomLayerType_Assets:
+                    free(layer->assetsData->legacyTiles);
+                    free(layer->assetsData->sprites);
+                    free(layer->assetsData);
+                    break;
+                case RoomLayerType_Background:
+                    free(layer->backgroundData);
+                    break;
+                case RoomLayerType_Instances:
+                    free(layer->instancesData->instanceIds);
+                    free(layer->instancesData);
+                    break;
+                case RoomLayerType_Tiles:
+                    free(layer->tilesData->tileData);
+                    free(layer->tilesData);
+                    break;
             }
         }
         free(room->layers);

--- a/src/data_win.c
+++ b/src/data_win.c
@@ -1607,18 +1607,9 @@ static void readRoomTiles(BinaryReader* reader, DataWin* dw, Room* room, uint32_
     free(tilePtrs);
 }
 
-static void readRoomLayers(BinaryReader* reader, DataWin* dw, Room* room) {
-    uint32_t layerCount;
-    uint32_t* layerPtrs = readPointerTable(reader, &layerCount);
-    room->layerCount = layerCount;
+static void readRoomLayers(BinaryReader* reader, DataWin* dw, Room* room, uint32_t* layerPtrs) {
+    uint32_t layerCount = room->layerCount;
 
-    if (layerCount == 0) {
-        room->layers = nullptr;
-        free(layerPtrs);
-        return;
-    }
-
-    room->layers = (RoomLayer *)safeMalloc(layerCount * sizeof(RoomLayer));
     repeat(layerCount, j) {
         BinaryReader_seek(reader, layerPtrs[j]);
         RoomLayer* layer = &room->layers[j];
@@ -1825,12 +1816,31 @@ static void readRoomPayload(BinaryReader* reader, DataWin* dw, Room* room) {
     uint32_t* tilePtrs = readPointerTable(reader, &tileCount);
     room->tileCount = tileCount;
 
+    uint32_t layerCount = 0;
+    uint32_t* layerPtrs;
+    if (room->layersFileOffset != 0) {
+        BinaryReader_seek(reader, room->layersFileOffset);
+        layerPtrs = readPointerTable(reader, &layerCount);
+    }
+    room->layerCount = layerCount;
+
     char *ptr = (char *)safeMalloc(
+        (layerCount * sizeof(RoomLayer)) +
         (8 * sizeof(RoomBackground)) +
         (8 * sizeof(RoomView)) +
         (objCount * sizeof(RoomGameObject)) +
         (tileCount * sizeof(RoomTile))
     );
+    // Layers must come first because it has pointer members,
+    // so the alignment requirements are stricter.
+    // Because layers can be null, the pointer to free could be
+    // in either layers or backgrounds, the free function must
+    // account for this.
+    if (layerCount > 0)
+        room->layers = (RoomLayer *)ptr;
+    else
+        room->layers = nullptr;
+    ptr += (layerCount * sizeof(RoomLayer));
     room->backgrounds = (RoomBackground *)ptr;
     ptr += (8 * sizeof(RoomBackground));
     room->views = (RoomView *)ptr;
@@ -1857,11 +1867,9 @@ static void readRoomPayload(BinaryReader* reader, DataWin* dw, Room* room) {
     BinaryReader_seek(reader, room->tilesFileOffset + (sizeof(uint32_t) * (tileCount + 1)));
     readRoomTiles(reader, dw, room, tilePtrs);
 
-    room->layerCount = 0;
-    room->layers = nullptr;
-    if (room->layersFileOffset != 0) {
-        BinaryReader_seek(reader, room->layersFileOffset);
-        readRoomLayers(reader, dw, room);
+    if (layerCount > 0) {
+        BinaryReader_seek(reader, room->layersFileOffset + (sizeof(uint32_t) * (layerCount + 1)));
+        readRoomLayers(reader, dw, room, layerPtrs);
     }
 
     room->payloadLoaded = true;
@@ -3014,8 +3022,6 @@ void DataWin_free(DataWin* dw) {
 
 void DataWin_freeRoomPayload(Room* room) {
     requireNotNull(room);
-    free(room->backgrounds);
-    room->backgrounds = nullptr;
     room->views = nullptr;
     room->gameObjects = nullptr;
     room->gameObjectCount = 0;
@@ -3039,8 +3045,10 @@ void DataWin_freeRoomPayload(Room* room) {
                 free(layer->tilesData);
             }
         }
-    }
-    free(room->layers);
+        free(room->layers);
+    } else
+        free(room->backgrounds);
+    room->backgrounds = nullptr;
     room->layers = nullptr;
     room->layerCount = 0;
     room->payloadLoaded = false;

--- a/src/data_win.h
+++ b/src/data_win.h
@@ -663,10 +663,12 @@ typedef struct {
     float hSpeed;
     float vSpeed;
     bool visible;
-    RoomLayerAssetsData *assetsData;
-    RoomLayerBackgroundData *backgroundData;
-    RoomLayerInstancesData *instancesData;
-    RoomLayerTilesData *tilesData;
+    union {
+        RoomLayerInstancesData *instancesData;
+        RoomLayerAssetsData *assetsData;
+        RoomLayerBackgroundData *backgroundData;
+        RoomLayerTilesData *tilesData;
+    };
 } RoomLayer;
 
 typedef struct {

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -997,10 +997,6 @@ char* collapseNewlines(const char *input) {
 
 // ===[ MAIN ]===
 int main(int argc, char* argv[]) {
-    fprintf(stderr, "%zu\n", sizeof(RoomBackground));
-    fprintf(stderr, "%zu\n", sizeof(RoomView));
-    fprintf(stderr, "%zu\n", sizeof(RoomGameObject));
-    fprintf(stderr, "%zu\n", sizeof(RoomTile));
     setbuf(stderr, NULL);
 #ifdef _WIN32
     timeBeginPeriod(1);

--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -997,6 +997,10 @@ char* collapseNewlines(const char *input) {
 
 // ===[ MAIN ]===
 int main(int argc, char* argv[]) {
+    fprintf(stderr, "%zu\n", sizeof(RoomBackground));
+    fprintf(stderr, "%zu\n", sizeof(RoomView));
+    fprintf(stderr, "%zu\n", sizeof(RoomGameObject));
+    fprintf(stderr, "%zu\n", sizeof(RoomTile));
     setbuf(stderr, NULL);
 #ifdef _WIN32
     timeBeginPeriod(1);


### PR DESCRIPTION
I can't tell exactly how much memory this saves, but it definitely saves something.