### PR TITLE
fix(vm): mp_grid_path sets path to straight and open by default

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -14983,8 +14983,10 @@ static RValue builtin_mp_grid_path(VMContext* ctx, RValue* args, int32_t argCoun
     pPath->internalPoints = nullptr;
     pPath->internalPointCount = 0;
     pPath->length = 0.0f;
-    GamePath_computeInternal(pPath);
+    pPath->isSmooth = false;
+    pPath->isClosed = false;
 
+    GamePath_computeInternal(pPath);
     return RValue_makeBool(true);
 }
 


### PR DESCRIPTION
Fixes issue #336, where entering the desert at the start of chapter 3 causes a softlock, as Susie and Ralsei don't follow their path correctly.

This is caused my `mp_grid_path` not setting the path to be open and straight by default. I verified this by running the following script in GameMaker:

```gml
// Create a grid
var cell_size = 32;
var grid_w = 10;
var grid_h = 10;

global.test_grid = mp_grid_create(0, 0, grid_w, grid_h, cell_size, cell_size);

// Add some obstacles
mp_grid_add_cell(global.test_grid, 4, 3);
mp_grid_add_cell(global.test_grid, 4, 4);
mp_grid_add_cell(global.test_grid, 4, 5);
mp_grid_add_cell(global.test_grid, 5, 5);
mp_grid_add_cell(global.test_grid, 6, 5);

// Create a path
global.test_path = path_add();

// Find path from (1,1) to (8,8)
var found = mp_grid_path(
    global.test_grid,
    global.test_path,
    1 * cell_size + cell_size / 2,
    1 * cell_size + cell_size / 2,
    8 * cell_size + cell_size / 2,
    8 * cell_size + cell_size / 2,
    true
);

show_debug_message("found = " + string(found));

if (found)
{
    show_debug_message("closed = " + string(path_get_closed(global.test_path)));
    show_debug_message("points = " + string(path_get_number(global.test_path)));
    show_debug_message("length = " + string(path_get_length(global.test_path)));
    show_debug_message("smooth = " + string(path_get_kind(global.test_path)));
}
```

and I got the following output:

```
found = 1
closed = 0
points = 11
length = 373.02
smooth = 0
```

As seen, the path is open and straight by default.