### PR TITLE
fix(paths): Set default speed of PathPositionResult to 100

### DIFF
--- a/src/data_win.c
+++ b/src/data_win.c
@@ -236,7 +236,11 @@ void GamePath_computeInternal(GamePath* path) {
 
 // Get interpolated position at t in [0,1] (yyPath.js:362-409)
 PathPositionResult GamePath_getPosition(GamePath* path, float t) {
-    PathPositionResult result = {0};
+    PathPositionResult result = {
+        .x = 0.0f,
+        .y = 0.0f,
+        .speed = 100.0f,
+    };
 
     if (path->internalPointCount == 0) return result;
 

--- a/src/data_win.c
+++ b/src/data_win.c
@@ -236,11 +236,8 @@ void GamePath_computeInternal(GamePath* path) {
 
 // Get interpolated position at t in [0,1] (yyPath.js:362-409)
 PathPositionResult GamePath_getPosition(GamePath* path, float t) {
-    PathPositionResult result = {
-        .x = 0.0f,
-        .y = 0.0f,
-        .speed = 100.0f,
-    };
+    PathPositionResult result = {0};
+    result.speed = 100.0f;
 
     if (path->internalPointCount == 0) return result;
 


### PR DESCRIPTION
Default value of speed on a point is 100, not 0.

Tested on GameMaker Runtime 2026.0.0.23, using the following script:

```gml
var p = path_add();

path_add_point(p, 0, 0, 250);
path_clear_points(p);

show_debug_message(path_get_speed(p, 0));
```

In GameMaker, this outputs 100. In Butterscotch, this would previously output 0.