### PR TITLE
fix(paths): add "exists" bool to GamePath

### DIFF
--- a/src/data_win.c
+++ b/src/data_win.c
@@ -1029,6 +1029,7 @@ static void parsePATH(BinaryReader* reader, DataWin* dw) {
         path->isSmooth = BinaryReader_readBool32(reader);
         path->isClosed = BinaryReader_readBool32(reader);
         path->precision = BinaryReader_readUint32(reader);
+        path->exists = true;
 
         // Points SimpleList
         path->pointCount = BinaryReader_readUint32(reader);

--- a/src/data_win.h
+++ b/src/data_win.h
@@ -317,6 +317,7 @@ typedef struct {
     uint32_t internalPointCount;
     InternalPathPoint* internalPoints;
     float length; // total arc length
+    bool exists;
 } GamePath;
 
 typedef struct {

--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -14428,7 +14428,9 @@ static RValue builtin_throw(VMContext* ctx, RValue* args, int32_t argCount) {
 static GamePath* getPath(Runner* runner, int32_t pathIdx) {
     if (0 > pathIdx) return nullptr;
     if ((uint32_t) pathIdx >= runner->dataWin->path.count) return nullptr;
-    return &runner->dataWin->path.paths[pathIdx];
+    
+    GamePath* p = &runner->dataWin->path.paths[pathIdx];
+    return p->exists ? p : nullptr;
 }
 
 // path_add() - create a new empty path, return its index
@@ -14450,6 +14452,7 @@ static RValue builtin_path_add(VMContext* ctx, MAYBE_UNUSED RValue* args, MAYBE_
     p->internalPointCount = 0;
     p->internalPoints = nullptr;
     p->length = 0.0;
+    p->exists = true;
     pc->count = newIdx + 1;
     return RValue_makeInt32((int32_t) newIdx);
 }
@@ -14499,6 +14502,7 @@ static RValue builtin_path_delete(VMContext* ctx, RValue* args, int32_t argCount
     free(p->points); p->points = nullptr; p->pointCount = 0;
     free(p->internalPoints); p->internalPoints = nullptr; p->internalPointCount = 0;
     p->length = 0.0;
+    p->exists = false;
     return RValue_makeUndefined();
 }
 


### PR DESCRIPTION
This adds a bool labelled "exists" to GamePath. In parsePATH and path_add, exists is set to true, and in path_delete, exists is set to false. getPath now returns nullptr if exists is false. 

This is more in line with actual GameMaker behaviour. In GameMaker Runtime 2026.0.0.23, running `path_delete(p)` on a previously created apth makes `path_exists(p)`, return false, however in Butterscotch this would still return true.