### PR TITLE
Make fast forward bools non-static

### DIFF
--- a/src/desktop/main.c
+++ b/src/desktop/main.c
@@ -1016,6 +1016,8 @@ int main(int argc, char* argv[]) {
     bool platformInitialized = false;
     int32_t inputFrameCount = 0;
 
+    bool fastForwardActive = false;
+    bool fastForwardTabPrev = false;
     while (true) {
         fprintf(stderr, "Loading %s...\n", args.dataWinPath);
 
@@ -1803,8 +1805,6 @@ int main(int argc, char* argv[]) {
 
             // Limit frame rate to room speed (skip in headless mode for max speed!!)
             if (!args.headless && runner->currentRoom->speed > 0) {
-                static bool fastForwardActive = false;
-                static bool fastForwardTabPrev = false;
                 bool fastForwardTabNow = RunnerKeyboard_checkPressed(runner->keyboard, VK_TAB);
                 if (args.fastForwardSpeed > 0.0 && fastForwardTabNow && !fastForwardTabPrev) {
                     fastForwardActive = !fastForwardActive;


### PR DESCRIPTION
Before, the fast-forward state would be saved across game launches on stuff like iOS where a return from main doesn't mean the process ends.