### PR TITLE
fix(vm): tag binary-op result with the wider operand type (Susie's outfit crash)

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -124,6 +124,20 @@ static uint8_t instrType2(uint32_t instr) {
     return (instr >> 20) & 0xF;
 }
 
+// The result of a numeric binary op (add/sub/mul/div/mod/rem and bitwise) is declared on the
+// stack with the WIDER of the two operand types. gmlStackType feeds the byte-count model in
+// bytesToSlotCount (used by the Dup swap variant and BC17 BREAK sub-opcodes), so it must match
+// the width the compiler assigned. Tagging with instrType2 alone under-sizes the result when
+// type1 is wider than type2 (e.g. add.v.i: Variable + int -> the result is a Variable-width
+// 16B slot, not an int 4B). When such a result feeds a `.v` Dup-swap over a method-call arg
+// list with no intervening Conv, the under-sized tag makes bytesToSlotCount overshoot a slot
+// boundary and abort at `require(remaining == 0)`.
+static uint8_t binaryResultType(uint32_t instr) {
+    uint8_t t1 = instrType1(instr);
+    uint8_t t2 = instrType2(instr);
+    return (gmlTypeNativeSize(t1) > gmlTypeNativeSize(t2)) ? t1 : t2;
+}
+
 static int16_t instrInstanceType(uint32_t instr) {
     return (int16_t) (instr & 0xFFFF);
 }
@@ -1547,7 +1561,7 @@ static void handleDiv(VMContext* ctx, uint32_t instr) {
     GMLReal result = RValue_toReal(a) / divisor;
     RValue_free(&a);
     RValue_free(&b);
-    stackPushTyped(ctx, RValue_makeReal(result), instrType2(instr));
+    stackPushTyped(ctx, RValue_makeReal(result), binaryResultType(instr));
 }
 
 static void handleRem(VMContext* ctx, uint32_t instr) {
@@ -1558,7 +1572,7 @@ static void handleRem(VMContext* ctx, uint32_t instr) {
     int64_t result = RValue_toInt64(a) / divisor;
     RValue_free(&a);
     RValue_free(&b);
-    stackPushTyped(ctx, RValue_makeInt64(result), instrType2(instr));
+    stackPushTyped(ctx, RValue_makeInt64(result), binaryResultType(instr));
 }
 
 static void handleMod(VMContext* ctx, uint32_t instr) {
@@ -1569,14 +1583,14 @@ static void handleMod(VMContext* ctx, uint32_t instr) {
     GMLReal result = GMLReal_fmod(RValue_toReal(a), divisor);
     RValue_free(&a);
     RValue_free(&b);
-    stackPushTyped(ctx, RValue_makeReal(result), instrType2(instr));
+    stackPushTyped(ctx, RValue_makeReal(result), binaryResultType(instr));
 }
 
 #define SIMPLE_BYTECODE_BITWISE_OPERATION(op) \
     int32_t b = stackPopInt32(ctx); \
     int32_t a = stackPopInt32(ctx); \
     int32_t result = a op b; \
-    stackPushTyped(ctx, RValue_makeInt32(result), instrType2(instr))
+    stackPushTyped(ctx, RValue_makeInt32(result), binaryResultType(instr))
 
 static void handleAnd(VMContext* ctx, uint32_t instr) {
     SIMPLE_BYTECODE_BITWISE_OPERATION(&);
@@ -3037,10 +3051,10 @@ static RValue executeLoop(VMContext* ctx) {
                         slotA->real = aVal + bVal;
                         slotA->type = RVALUE_REAL;
                     }
-                    slotA->gmlStackType = instrType2(instr);
+                    slotA->gmlStackType = binaryResultType(instr);
                     ctx->stack.top--;
                 } else {
-                    uint8_t resultType = instrType2(instr);
+                    uint8_t resultType = binaryResultType(instr);
                     RValue b = stackPop(ctx);
                     RValue a = stackPop(ctx);
                     if (a.type == RVALUE_STRING || b.type == RVALUE_STRING) {
@@ -3074,10 +3088,10 @@ static RValue executeLoop(VMContext* ctx) {
                         slotA->real = aVal - bVal;
                         slotA->type = RVALUE_REAL;
                     }
-                    slotA->gmlStackType = instrType2(instr);
+                    slotA->gmlStackType = binaryResultType(instr);
                     ctx->stack.top--;
                 } else {
-                    uint8_t resultType = instrType2(instr);
+                    uint8_t resultType = binaryResultType(instr);
                     RValue b = stackPop(ctx);
                     RValue a = stackPop(ctx);
 #ifndef NO_RVALUE_INT64
@@ -3107,10 +3121,10 @@ static RValue executeLoop(VMContext* ctx) {
                         slotA->real = aVal * bVal;
                         slotA->type = RVALUE_REAL;
                     }
-                    slotA->gmlStackType = instrType2(instr);
+                    slotA->gmlStackType = binaryResultType(instr);
                     ctx->stack.top--;
                 } else {
-                    uint8_t resultType = instrType2(instr);
+                    uint8_t resultType = binaryResultType(instr);
                     RValue b = stackPop(ctx);
                     RValue a = stackPop(ctx);
                     if (a.type == RVALUE_STRING) {


### PR DESCRIPTION
### Problem
Arithmetic and bitwise handlers tag the result slot's `gmlStackType` with
`instrType2(instr)` (OP_ADD/SUB/MUL fast+slow, handleDiv/Rem/Mod, the bitwise
macro). A numeric binary op's result should take the **wider** of the two
operand types. When `type1` is wider than `type2` — e.g. `add.v.i` (Variable +
int) — the result is mis-tagged as the narrow type (INT32, 4 bytes) instead of
Variable (16 bytes). Since `gmlStackType` drives the byte-count model in
`bytesToSlotCount` (used by the `Dup` swap variant and BC17 `BREAK`
sub-opcodes), the mismatch makes the byte walk overshoot a slot boundary and
abort at `require(remaining == 0)`.

### Reproduce
DELTARUNE Chapter 5, Susie's outfit ("thrashfit") menu —
`obj_ch5_LW07_thrashfit_menu.show_menu` calls
`option.init(id, label, names, flag, 170 + ja_offset)`. The last argument
`170 + ja_offset` compiles to `add.v.i` with **no following `Conv`** and flows
straight into the `dup.v` swap that arranges the 5-argument method call. The
swap expects `5 * sizeof(Variable) = 80` bytes; the mis-tagged INT32 argument
makes the real slots sum to `4 + 16*4 = 68` → `remaining = -4` → abort. The
preceding 4-argument `init` (all Variables, `64 = 4*16`) is fine, so it aborts
precisely on the first right-column option.

### Fix
    static uint8_t binaryResultType(uint32_t instr) {
        uint8_t t1 = instrType1(instr), t2 = instrType2(instr);
        return (gmlTypeNativeSize(t1) > gmlTypeNativeSize(t2)) ? t1 : t2;
    }
Used at every binary-op result-tag site. It differs from `instrType2` **only**
when `type1` is strictly wider than `type2` (the buggy case), so it cannot
regress working code. `gmlStackType` is read only by `bytesToSlotCount`, so
widening the tag never changes a value's runtime interpretation — only the
byte-count model.

### Relation to #340
Fixes the same crash as #340 ("Susie's outfit"), but at the root cause — the
mis-tagged operand — instead of changing the `Dup` swap decoding. Because it
leaves the `Dup`/`bytesToSlotCount` byte-count model untouched, it does not
affect legitimate mixed-width `Dup`-swaps, so it should avoid the save-menu /
save-deletion regression noted on #340.

### Verification
- Builds clean (Release), no new warnings.
- Passes the headless tests (`object-index-iteration`, `struct-get-names`,
  `simple-structs-methods-and-dynamic-methods`).
- Verified on a downstream PSP port: the Chapter 5 costume menu, which
  previously aborted at `require(remaining == 0)`, now opens correctly.