### PR TITLE
Always set NO_STRCASECMP for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,7 @@ if(PLATFORM STREQUAL "desktop")
     if (MSVC)
         target_include_directories(butterscotch PRIVATE ${CMAKE_SOURCE_DIR}/compat/getopt)
         add_compile_definitions(NO_STRTOK_R)
+        add_compile_definitions(NO_STRCASECMP)
     endif()
 
     # Butterscotch VM/interpreter profiler


### PR DESCRIPTION
Even modern MSVC doesn't have this function, it's actually POSIX, not standard C.
At some point I should hook these up to proper function checks like the makefile build does.  I'm pretty sure cmake has a way to do that.