### PR TITLE
Added RLE tile data checks if it's GM 2024.2 or 2024.4 if aligned

### DIFF
--- a/src/data_win.c
+++ b/src/data_win.c
@@ -2102,7 +2102,6 @@ static void parseROOM(BinaryReader* reader, DataWin* dw, bool lazyLoadRooms, Str
             BinaryReader_skip(reader, 22 * 4);
 
             uint32_t layersPtr = BinaryReader_readUint32(reader);
-            uint32_t seqnPtr = BinaryReader_readUint32(reader);
 
             BinaryReader_seek(reader, layersPtr);
             uint32_t layerCount = BinaryReader_readUint32(reader);

--- a/src/data_win.c
+++ b/src/data_win.c
@@ -2039,6 +2039,92 @@ static void parseROOM(BinaryReader* reader, DataWin* dw, bool lazyLoadRooms, Str
         }
     }
 
+    // Detect RLE-compressed tile data (Added in GMS 2024.2)
+    if (DataWin_isVersionAtLeast(dw, 2023, 2, 0, 0) && !DataWin_isVersionAtLeast(dw, 2024, 2, 0, 0)) {
+        // Iterate over rooms to find tile layers
+        repeat(count, i) {
+            if (ptrs[i] == 0) continue;
+
+            BinaryReader_seek(reader, ptrs[i]);
+            BinaryReader_skip(reader, 22 * 4); // Skip to layersPtr
+
+            uint32_t layersPtr = BinaryReader_readUint32(reader);
+            uint32_t seqnPtr = BinaryReader_readUint32(reader);
+
+            BinaryReader_seek(reader, layersPtr);
+            uint32_t layerCount = BinaryReader_readUint32(reader);
+            if (layerCount <= 0) continue;
+
+            bool found2024_2 = false;
+
+            for (uint32_t layerNum = 0; layerNum < layerCount; layerNum++) {
+                size_t layerPtr = (size_t)(layersPtr + 4 + (4 * layerNum));
+                BinaryReader_seek(reader, layerPtr + 4);
+
+                uint32_t jumpOffset = BinaryReader_readUint32(reader) + 8;
+                uint32_t nextOffset = (layerNum == layerCount - 1) ? seqnPtr : BinaryReader_readUint32(reader);
+
+                BinaryReader_seek(reader, jumpOffset);
+                uint32_t layerType = BinaryReader_readUint32(reader);
+
+                if (layerType != RoomLayerType_Tiles) continue;
+
+                // Skip to tile map dimensions
+                BinaryReader_skip(reader, 32);
+                uint32_t effectCount = BinaryReader_readUint32(reader);
+                BinaryReader_skip(reader, effectCount * 12 + 4);
+
+                uint32_t tileMapWidth = BinaryReader_readUint32(reader);
+                uint32_t tileMapHeight = BinaryReader_readUint32(reader);
+                uint32_t expectedRawSize = tileMapWidth * tileMapHeight * 4;
+                uint32_t actualRemaining = nextOffset - (uint32_t)BinaryReader_getPosition(reader);
+
+                // If sizes don't match, it's RLE compressed -> 2024.2+
+                if (actualRemaining != expectedRawSize) {
+                    DataWin_bumpVersionTo(dw, 2024, 2, 0, 0);
+                    found2024_2 = true;
+                    break;
+                }
+            }
+
+            if (found2024_2) break;
+        }
+    }
+
+    // Detect alignment after the stream of said RLE data (Added in GMS 2024.4)
+    if (DataWin_isVersionAtLeast(dw, 2024, 2, 0, 0) && !DataWin_isVersionAtLeast(dw, 2024, 4, 0, 0)) {
+        bool hasNonAlignedLayer = false;
+
+        repeat(count, i) {
+            if (ptrs[i] == 0) continue;
+
+            BinaryReader_seek(reader, ptrs[i]);
+            BinaryReader_skip(reader, 22 * 4);
+
+            uint32_t layersPtr = BinaryReader_readUint32(reader);
+            uint32_t seqnPtr = BinaryReader_readUint32(reader);
+
+            BinaryReader_seek(reader, layersPtr);
+            uint32_t layerCount = BinaryReader_readUint32(reader);
+            if (layerCount <= 0) continue;
+
+            for (uint32_t layerNum = 0; layerNum < layerCount; layerNum++) {
+                size_t layerPtr = (size_t)(layersPtr + 4 + (4 * layerNum));
+                if (layerPtr % 4 != 0) {
+                    hasNonAlignedLayer = true;
+                    break;
+                }
+            }
+
+            if (hasNonAlignedLayer) break;
+        }
+
+        // If no non-aligned layers found, it's 2024.4+
+        if (!hasNonAlignedLayer) {
+            DataWin_bumpVersionTo(dw, 2024, 4, 0, 0);
+        }
+    }
+
     rc->rooms = (Room *)safeCalloc(count, sizeof(Room));
     repeat(count, i) {
         if (ptrs[i] == 0) { rc->rooms[i].creationCodeId = -1; continue; }


### PR DESCRIPTION
Fixes games made in a lower 2024.x version being misreported as 2023.2, causing garbled tile data being rendered.

Checks are taken from UTMT since the version was being reported correctly there.

Tested on MotionRec Demo, where the background wasn't showing properly.