### PR TITLE
Better standards compliance

### DIFF
--- a/compat/configure.sh
+++ b/compat/configure.sh
@@ -242,6 +242,16 @@ int main(void){return 0;}
 fi
 
 printf '%s' "\
+#include <strings.h>
+int main(void){return 0;}
+" > tmp/test.c
+
+if ! nolink=1 check 'if strings.h works'; then
+    define 'NO_STRINGS_H'
+    no_strings_h=1
+fi
+
+printf '%s' "\
 #include <stdio.h>
 int main(void){
     puts(__func__);
@@ -392,12 +402,17 @@ if ! check 'for strtok_r'; then
     define 'NO_STRTOK_R'
 fi
 
+if [ -n "$no_strings_h" ]; then
+    printf '#include <string.h>' > tmp/test.c
+else
+    printf '#include <strings.h>' > tmp/test.c
+fi
+
 printf '%s' "\
-#include <strings.h>
 int main(void){
     return strcasecmp(\"\", \"\");
 }
-" > tmp/test.c
+" >> tmp/test.c
 
 if ! check 'for strcasecmp'; then
     define 'NO_STRCASECMP'

--- a/compat/configure.sh
+++ b/compat/configure.sh
@@ -403,9 +403,9 @@ if ! check 'for strtok_r'; then
 fi
 
 if [ -n "$no_strings_h" ]; then
-    printf '#include <string.h>' > tmp/test.c
+    printf '#include <string.h>\n' > tmp/test.c
 else
-    printf '#include <strings.h>' > tmp/test.c
+    printf '#include <strings.h>\n' > tmp/test.c
 fi
 
 printf '%s' "\

--- a/src/data_win.c
+++ b/src/data_win.c
@@ -1186,7 +1186,8 @@ static void parseSHDR(BinaryReader* reader, DataWin* dw) {
     Shdr* s = &dw->shdr;
 
     uint32_t* ptrs = readPointerTable(reader, &s->count);
-    s->shaders = (Shader *)safeMalloc(s->count * sizeof(Shader));
+    if (s->count > 0)
+        s->shaders = (Shader *)safeMalloc(s->count * sizeof(Shader));
 
     repeat(s->count, i) {
         // Some GameMaker games have a nullptr for the shader, so we'll just mark them as not-present...

--- a/src/string_compat.h
+++ b/src/string_compat.h
@@ -2,6 +2,7 @@
 #define _BS_STRING_COMPAT_H_
 
 #include <string.h>
+#include <strings.h>
 
 #ifdef NO_STRCASECMP
 

--- a/src/string_compat.h
+++ b/src/string_compat.h
@@ -2,13 +2,18 @@
 #define _BS_STRING_COMPAT_H_
 
 #include <string.h>
+#ifndef NO_STRINGS_H
 #include <strings.h>
+#endif
 
 #ifdef NO_STRCASECMP
 
 #include <ctype.h>
 
 static int strcasecmp(const char *_s1, const char *_s2) {
+#ifdef _WIN32
+    return _stricmp(_s1, _s2);
+#else
     const unsigned char *s1 = (const unsigned char *)_s1;
     const unsigned char *s2 = (const unsigned char *)_s2;
 
@@ -19,6 +24,7 @@ static int strcasecmp(const char *_s1, const char *_s2) {
         ++s2;
     }
     return tolower(*s1) - tolower(*s2);
+#endif
 }
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -83,6 +83,10 @@ static inline void* requireNotNullFunction(void* ptr, const char* file, int line
 // Safe allocation macros - check for nullptr and abort with file/line info
 static inline void *safeMallocFunction(size_t size, const char *file, int line) {
     void *ret = malloc(size);
+#ifndef NDEBUG
+    if (size == 0)
+        ret = nullptr;
+#endif
     if (!ret) {
         fprintf(stderr, "FATAL: malloc(%zu) failed at %s:%d\n", size, file, line);
         abort();
@@ -93,6 +97,10 @@ static inline void *safeMallocFunction(size_t size, const char *file, int line) 
 
 static inline void *safeCallocFunction(size_t count, size_t size, const char *file, int line) {
     void *ret = calloc(count, size);
+#ifndef NDEBUG
+    if (size == 0 || count == 0)
+        ret = nullptr;
+#endif
     if (!ret) {
         fprintf(stderr, "FATAL: calloc(%zu, %zu) failed at %s:%d\n", count, size, file, line);
         abort();
@@ -103,6 +111,10 @@ static inline void *safeCallocFunction(size_t count, size_t size, const char *fi
 
 static inline void *safeReallocFunction(void *ptr, size_t size, const char *file, int line) {
     void *ret = realloc(ptr, size);
+#ifndef NDEBUG
+    if (size == 0)
+        ret = nullptr;
+#endif
     if (!ret) {
         fprintf(stderr, "FATAL: realloc(%zu) failed at %s:%d\n", size, file, line);
         abort();
@@ -115,6 +127,10 @@ static inline void *safeReallocFunction(void *ptr, size_t size, const char *file
 
 static inline void *safeMemalignFunction(size_t alignment, size_t size, const char *file, int line) {
     void *ret = memalign(alignment, size);
+#ifndef NDEBUG
+    if (size == 0)
+        ret = nullptr;
+#endif
     if (!ret) {
         fprintf(stderr, "FATAL: memalign(%zu, %zu) failed at %s:%d\n", alignment, size, file, line);
         abort();


### PR DESCRIPTION
POSIX says strcasecmp is only in strings.h, most systems put it in string.h too because it was there in 4.4 BSD where it originated, but not all.  To fix this I made string_compat.h include strings.h if it's present.  I also modified the strcasecmp configure check to work on systems without strings.h.

malloc(0) is allowed to return NULL, the shader parser loader thing would call malloc(0) when loading a game without any shaders (like undertale) and that would crash because safeMalloc would catch the NULL.  This is fixed by just skipping the malloc call if there are no shaders to load.  This also prolly saves an infinitesimally small amount of memory, like 16 bytes or something.  I also added checks in debug mode that should prevent this from happening again without being caught.

Also I made the strcasecmp stub call _stricmp on windows, which is exactly equivalent, as suggested by @cobaltgit.

I found these issues when trying to make an OpenWatcom v2 build work, but they're not actually related to OpenWatcom inherently, so they're in a different PR.