### PR TITLE
consistent behavior of malloc with size 0

### DIFF
--- a/src/data_win.c
+++ b/src/data_win.c
@@ -1186,8 +1186,7 @@ static void parseSHDR(BinaryReader* reader, DataWin* dw) {
     Shdr* s = &dw->shdr;
 
     uint32_t* ptrs = readPointerTable(reader, &s->count);
-    if (s->count > 0)
-        s->shaders = (Shader *)safeMalloc(s->count * sizeof(Shader));
+    s->shaders = (Shader *)safeMalloc(s->count * sizeof(Shader));
 
     repeat(s->count, i) {
         // Some GameMaker games have a nullptr for the shader, so we'll just mark them as not-present...

--- a/src/utils.h
+++ b/src/utils.h
@@ -82,11 +82,9 @@ static inline void* requireNotNullFunction(void* ptr, const char* file, int line
 
 // Safe allocation macros - check for nullptr and abort with file/line info
 static inline void *safeMallocFunction(size_t size, const char *file, int line) {
-    void *ret = malloc(size);
-#ifndef NDEBUG
     if (size == 0)
-        ret = nullptr;
-#endif
+        return nullptr;
+    void *ret = malloc(size);
     if (!ret) {
         fprintf(stderr, "FATAL: malloc(%zu) failed at %s:%d\n", size, file, line);
         abort();
@@ -96,11 +94,9 @@ static inline void *safeMallocFunction(size_t size, const char *file, int line) 
 #define safeMalloc(size) safeMallocFunction(size, __FILE__, __LINE__)
 
 static inline void *safeCallocFunction(size_t count, size_t size, const char *file, int line) {
-    void *ret = calloc(count, size);
-#ifndef NDEBUG
     if (size == 0 || count == 0)
-        ret = nullptr;
-#endif
+        return nullptr;
+    void *ret = calloc(count, size);
     if (!ret) {
         fprintf(stderr, "FATAL: calloc(%zu, %zu) failed at %s:%d\n", count, size, file, line);
         abort();
@@ -110,11 +106,11 @@ static inline void *safeCallocFunction(size_t count, size_t size, const char *fi
 #define safeCalloc(count, size) safeCallocFunction(count, size, __FILE__, __LINE__)
 
 static inline void *safeReallocFunction(void *ptr, size_t size, const char *file, int line) {
+    if (size == 0) {
+        free(ptr);
+        return nullptr;
+    }
     void *ret = realloc(ptr, size);
-#ifndef NDEBUG
-    if (size == 0)
-        ret = nullptr;
-#endif
     if (!ret) {
         fprintf(stderr, "FATAL: realloc(%zu) failed at %s:%d\n", size, file, line);
         abort();
@@ -126,11 +122,9 @@ static inline void *safeReallocFunction(void *ptr, size_t size, const char *file
 #ifdef PLATFORM_PS2
 
 static inline void *safeMemalignFunction(size_t alignment, size_t size, const char *file, int line) {
-    void *ret = memalign(alignment, size);
-#ifndef NDEBUG
     if (size == 0)
-        ret = nullptr;
-#endif
+        return nullptr;
+    void *ret = memalign(alignment, size);
     if (!ret) {
         fprintf(stderr, "FATAL: memalign(%zu, %zu) failed at %s:%d\n", alignment, size, file, line);
         abort();

--- a/src/vm.c
+++ b/src/vm.c
@@ -3700,9 +3700,7 @@ RValue VM_executeCode(VMContext* ctx, int32_t codeIndex) {
     setCurrentCodeLocalsSlotMap(ctx);
 
     uint32_t localsCount = computeLocalsCount(ctx, code);
-    RValue* localVars = nullptr;
-    if (localsCount > 0)
-        localVars = (RValue *)safeCalloc(localsCount, sizeof(RValue));
+    RValue* localVars = (RValue *)safeCalloc(localsCount, sizeof(RValue));
     ctx->localVars = localVars;
     ctx->localVarCount = localsCount;
 


### PR DESCRIPTION
makes safeMalloc(0) and friends return NULL (and not crash).
Before the behavior was implementation defined, on some (most) platforms it could return a pointer that can't be accessed without UB, and on other platforms it would cause a crash because malloc(0) can return NULL.  This makes the behavior consistent across all implementations.  It also might save an extremely small amount of memory, but I wouldn't expect it to be more than a hundred bytes or so in the best case.