### PR TITLE
[vita] Fix texture preprocessing on legacy GL renderer

### DIFF
--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -438,6 +438,17 @@ bool GLLegacyRenderer_ensureTextureLoaded(GLLegacyRenderer* gl, uint32_t pageId)
 
     free(pixels);
 #else
+#if defined(PLATFORM_VITA)
+    if (VitaTextures_Active()) {
+        glBindTexture(GL_TEXTURE_2D, gl->glTextures[pageId]);
+        if (!VitaTextures_LoadPage(pageId, &gl->textureWidths[pageId], &gl->textureHeights[pageId])) {
+            fprintf(stderr, "GL: Failed to load Vita TXTR page %u", pageId);
+            return false;
+        }
+        fprintf(stderr, "GL: Loaded TXTR page %u (%dx%d)\n", pageId, gl->textureWidths[pageId], gl->textureHeights[pageId]);
+        return true;
+    }
+#endif
     DataWin* dw = gl->base.dataWin;
     Texture* txtr = &dw->txtr.textures[pageId];
 


### PR DESCRIPTION
I forgot to add some code the legacy GL renderer that loads in the preprocessed textures if they're active. My bad... 🥀 