### PR TITLE
Add macOS runner for building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
             ccache-macos-${{ matrix.label }}-
   
       - name: Configure
-        run: cmake -B build -G Ninja -DWERROR=ON -DDESKTOP_BACKEND=appkit -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+        run: cmake -B build -G Ninja -DWERROR=ON -DCMAKE_C_FLAGS="-Wno-deprecated-declarations" -DDESKTOP_BACKEND=appkit -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
   
       - name: Build
         run: cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,60 +33,6 @@ jobs:
         with:
           name: butterscotch-glfw-linux-x86_64
           path: build/butterscotch
-          
-  build-glfw-macos-arm64:
-    name: Build (GLFW/macOS arm64)
-    runs-on: macos-26
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get commit info
-        id: commit-info
-        run: |
-          echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "date=$(git log -1 --format=%cd --date=short)" >> $GITHUB_OUTPUT
-
-      - name: Install dependencies
-        run: brew install cmake glfw bzip2
-
-      - name: Configure
-        run: cmake -B build -DWERROR=ON -DDESKTOP_BACKEND=appkit -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
-
-      - name: Build
-        run: cmake --build build -- -j$(sysctl -n hw.ncpu)
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: butterscotch-glfw-macos-arm64
-          path: build/butterscotch
-
-  build-glfw-macos-x86_64:
-    name: Build (GLFW/macOS x86_64)
-    runs-on: macos-26-intel
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get commit info
-        id: commit-info
-        run: |
-          echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "date=$(git log -1 --format=%cd --date=short)" >> $GITHUB_OUTPUT
-
-      - name: Install dependencies
-        run: brew install cmake glfw bzip2
-
-      - name: Configure
-        run: cmake -B build -DWERROR=ON -DDESKTOP_BACKEND=appkit -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
-
-      - name: Build
-        run: cmake --build build -- -j$(sysctl -n hw.ncpu)
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: butterscotch-glfw-macos-x86_64
-          path: build/butterscotch
 
   build-glfw-windows-x86_64:
     name: Build (GLFW/Windows x86_64)
@@ -233,6 +179,42 @@ jobs:
           path: build/butterscotch.exe
       - name: Pack cache
         run: cd ~ && tar cJf ccache.tar.xz .cache/ccache workspacecache.tar
+  
+  build-glfw-macos:
+    name: Build (GLFW/macOS ${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: x86_64
+            runner: macos-26-intel
+          - label: arm64
+            runner: macos-26
+        
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+  
+      - name: Get commit info
+        id: commit-info
+        run: |
+          echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(git log -1 --format=%cd --date=short)" >> $GITHUB_OUTPUT
+  
+      - name: Install dependencies
+        run: brew install cmake ninja glfw bzip2
+  
+      - name: Configure
+        run: cmake -B build -G Ninja -DWERROR=ON -DDESKTOP_BACKEND=appkit -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+  
+      - name: Build
+        run: cmake --build build
+  
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: butterscotch-glfw-macos-${{ matrix.label }}
+          path: build/butterscotch
 
   build-ps2:
     name: Build (PS2)${{ matrix.label }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,10 +202,17 @@ jobs:
           echo "date=$(git log -1 --format=%cd --date=short)" >> $GITHUB_OUTPUT
   
       - name: Install dependencies
-        run: brew install cmake ninja glfw bzip2
+        run: brew install cmake ninja glfw bzip2 ccache
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-macos-${{ matrix.label }}-${{ github.sha }}
+          restore-keys: |
+            ccache-macos-${{ matrix.label }}-
   
       - name: Configure
-        run: cmake -B build -G Ninja -DWERROR=ON -DDESKTOP_BACKEND=appkit -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+        run: cmake -B build -G Ninja -DWERROR=ON -DDESKTOP_BACKEND=appkit -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
   
       - name: Build
         run: cmake --build build
@@ -213,7 +220,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: butterscotch-glfw-macos-${{ matrix.label }}
+          name: butterscotch-appkit-macos-${{ matrix.label }}
           path: build/butterscotch
 
   build-ps2:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           
   build-glfw-macos-arm64:
     name: Build (GLFW/macOS arm64)
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
 
@@ -63,47 +63,29 @@ jobs:
 
   build-glfw-macos-x86_64:
     name: Build (GLFW/macOS x86_64)
-    runs-on: macos-14
+    runs-on: macos-26-intel
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Rosetta
-        run: softwareupdate --install-rosetta --agree-to-license
-
-      - name: Install x86_64 Homebrew
-        run: |
-          arch -x86_64 /bin/bash -c \
-            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-      - name: Install dependencies
-        run: |
-          arch -x86_64 /usr/local/bin/brew install cmake glfw bzip2
 
       - name: Get commit info
         id: commit-info
         run: |
-          echo "hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          echo "date=$(git log -1 --format=%cd --date=short)" >> "$GITHUB_OUTPUT"
+          echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(git log -1 --format=%cd --date=short)" >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
+        run: brew install cmake glfw bzip2
 
       - name: Configure
-        run: |
-          arch -x86_64 /usr/local/bin/cmake -B build \
-            -DWERROR=ON \
-            -DDESKTOP_BACKEND=glfw3 \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_OSX_ARCHITECTURES=x86_64 \
-            "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" \
-            "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+        run: cmake -B build -DWERROR=ON -DDESKTOP_BACKEND=glfw3 -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
 
       - name: Build
-        run: |
-          arch -x86_64 /usr/local/bin/cmake --build build \
-            -- -j$(sysctl -n hw.ncpu)
+        run: cmake --build build -- -j$(sysctl -n hw.ncpu)
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: butterscotch-glfw-macos-x86_64
+          name: butterscotch-glfw-macos-amd64
           path: build/butterscotch
 
   build-glfw-windows-x86_64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
         run: cd ~ && tar cJf ccache.tar.xz .cache/ccache workspacecache.tar
   
   build-glfw-macos:
-    name: Build (GLFW/macOS ${{ matrix.label }})
+    name: Build (AppKit/macOS ${{ matrix.label }})
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,10 @@ jobs:
           echo "date=$(git log -1 --format=%cd --date=short)" >> $GITHUB_OUTPUT
   
       - name: Install dependencies
-        run: brew install cmake ninja glfw bzip2 ccache
+        run: brew install glfw ccache
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
 
       - uses: actions/cache@v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: butterscotch-glfw-macos-amd64
+          name: butterscotch-glfw-macos-x86_64
           path: build/butterscotch
 
   build-glfw-windows-x86_64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,33 @@ jobs:
         with:
           name: butterscotch-glfw-linux-x86_64
           path: build/butterscotch
+          
+  build-glfw-macos-arm64:
+    name: Build (GLFW/macOS arm64)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get commit info
+        id: commit-info
+        run: |
+          echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "date=$(git log -1 --format=%cd --date=short)" >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
+        run: brew install cmake glfw bzip2
+
+      - name: Configure
+        run: cmake -B build -DWERROR=ON -DDESKTOP_BACKEND=glfw3 -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+
+      - name: Build
+        run: cmake --build build -- -j$(sysctl -n hw.ncpu)
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: butterscotch-glfw-macos-arm64
+          path: build/butterscotch
 
   build-glfw-windows-x86_64:
     name: Build (GLFW/Windows x86_64)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
             ccache-macos-${{ matrix.label }}-
   
       - name: Configure
-        run: cmake -B build -G Ninja -DWERROR=ON -DCMAKE_C_FLAGS="-Wno-deprecated-declarations" -DDESKTOP_BACKEND=appkit -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+        run: cmake -B build -G Ninja -DWERROR=ON -DCMAKE_C_FLAGS="-Wno-deprecated-declarations" -DDESKTOP_BACKEND=appkit -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release
   
       - name: Build
         run: cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,51 @@ jobs:
           name: butterscotch-glfw-macos-arm64
           path: build/butterscotch
 
+  build-glfw-macos-x86_64:
+    name: Build (GLFW/macOS x86_64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rosetta
+        run: softwareupdate --install-rosetta --agree-to-license
+
+      - name: Install x86_64 Homebrew
+        run: |
+          arch -x86_64 /bin/bash -c \
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+      - name: Install dependencies
+        run: |
+          arch -x86_64 /usr/local/bin/brew install cmake glfw bzip2
+
+      - name: Get commit info
+        id: commit-info
+        run: |
+          echo "hash=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "date=$(git log -1 --format=%cd --date=short)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure
+        run: |
+          arch -x86_64 /usr/local/bin/cmake -B build \
+            -DWERROR=ON \
+            -DDESKTOP_BACKEND=glfw3 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_OSX_ARCHITECTURES=x86_64 \
+            "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" \
+            "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+
+      - name: Build
+        run: |
+          arch -x86_64 /usr/local/bin/cmake --build build \
+            -- -j$(sysctl -n hw.ncpu)
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: butterscotch-glfw-macos-x86_64
+          path: build/butterscotch
+
   build-glfw-windows-x86_64:
     name: Build (GLFW/Windows x86_64)
     runs-on: ubuntu-24.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         run: brew install cmake glfw bzip2
 
       - name: Configure
-        run: cmake -B build -DWERROR=ON -DDESKTOP_BACKEND=glfw3 -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+        run: cmake -B build -DWERROR=ON -DDESKTOP_BACKEND=appkit -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
 
       - name: Build
         run: cmake --build build -- -j$(sysctl -n hw.ncpu)
@@ -77,7 +77,7 @@ jobs:
         run: brew install cmake glfw bzip2
 
       - name: Configure
-        run: cmake -B build -DWERROR=ON -DDESKTOP_BACKEND=glfw3 -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
+        run: cmake -B build -DWERROR=ON -DDESKTOP_BACKEND=appkit -DCMAKE_BUILD_TYPE=Release "-DBUTTERSCOTCH_COMMIT_HASH=${{ steps.commit-info.outputs.hash }}" "-DBUTTERSCOTCH_COMMIT_DATE=${{ steps.commit-info.outputs.date }}"
 
       - name: Build
         run: cmake --build build -- -j$(sysctl -n hw.ncpu)


### PR DESCRIPTION
So we can see if macOS fails to build and also to provide users with macOS binaries from the actions if they don't want to compile it themselves c: