### PR TITLE
fix(vm): return false on isValidLayerSpriteElement if element is null

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -13754,9 +13754,12 @@ static RValue builtin_layer_tile_visible(VMContext* ctx, RValue* args, MAYBE_UNU
 }
 
 static bool isValidLayerSpriteElement(RuntimeLayerElement* element) {
-    bool isValid = element != nullptr && element->type == RuntimeLayerElementType_Sprite;
+    if (element == nullptr)
+        return false;
+    if (element->type != RuntimeLayerElementType_Sprite)
+        return false;
     requireNotNull(element->spriteElement); // If this crashes then something went DEEPLY wrong
-    return isValid;
+    return true;
 }
 
 static RValue builtin_layer_sprite_get_id(VMContext* ctx, RValue* args, MAYBE_UNUSED int32_t argCount) {


### PR DESCRIPTION
This returns false on isValidLayerSpriteElement if the element is null or if element->Type is not RuntimeLayerElementType_Sprite.

This fixes a crash loading gml_Object_obj_dw_garden_mushrooms_Step_0 in Deltarune Chapter 5, where it tries to load sprite 6480 from layer "NPCs", when that sprite ID does not exist in that layer.

A decompilation of the script shows the object calling:
```gml
mushrooms = [
    findsprite(8100, "NPCs", 0xFF00FF00 & 0xFFFFFF),
    findsprite(8100, "NPCs", 0x00FF00),
    findsprite(8100, "NPCs", 0xFF00FF),
    findsprite(8100, "NPCs", 0x00FFFF),
    findsprite(6840, "NPCs")
];
```

with findsprite being defined as

```gml
function findsprite(sprite_id, layer_name, blend, xscale, yscale, image_index, animation_speed);
```

in findsprite, the loop below is executed

```gml
for (var i = 0; i < array_length(layerstocheck); i++) {
    var elements = layer_get_all_elements(layerstocheck[i]);
    for (var j = 0; j < array_length(elements); j++) {
        if (layer_get_element_type(elements[j]) == layerelementtype_sprite) {
            if (layer_sprite_get_sprite(elements[j]) == argument0) {
                array_push(spritestocheck, elements[j]);
            }
        }
    }
}
```

Logging in readRoomLayers in datawin.c reveals that sprite index 6480 _does_ exist, but not in layer "NPC".

```Found sprite index 6840 in room layer 'FLOWERS' asset 'graphic_580943F9'```

This means that running `layer_sprite_get(elements[j])` in layer "NPCs" will never equal 6480, so the function will always return `-4`.