### PR TITLE
fix(vm): Set tilemap size return to -1 if element can't be found

### DIFF
--- a/src/vm_builtins.c
+++ b/src/vm_builtins.c
@@ -14085,7 +14085,7 @@ static RValue builtin_tilemap_get_width(VMContext* ctx, RValue* args, MAYBE_UNUS
 
 	RuntimeLayer* runtimeLayer;
     RoomLayerTilesData* data = findTilemapData(runner, RValue_toInt32(args[0]), &runtimeLayer);
-    if (!data) return RValue_makeUndefined();
+    if (!data) return RValue_makeReal(-1.0);
 
     return RValue_makeReal(data->tilesX);
 }
@@ -14096,7 +14096,7 @@ static RValue builtin_tilemap_get_height(VMContext* ctx, RValue* args, MAYBE_UNU
 
 	RuntimeLayer* runtimeLayer;
     RoomLayerTilesData* data = findTilemapData(runner, RValue_toInt32(args[0]), &runtimeLayer);
-    if (!data) return RValue_makeUndefined();
+    if (!data) return RValue_makeReal(-1.0);
 
     return RValue_makeReal(data->tilesY);
 }
@@ -14107,7 +14107,7 @@ static RValue builtin_tilemap_get_tile_width(VMContext* ctx, RValue* args, MAYBE
 
 	RuntimeLayer* runtimeLayer;
     RoomLayerTilesData* data = findTilemapData(runner, RValue_toInt32(args[0]), &runtimeLayer);
-	if (!data) return RValue_makeUndefined();
+	if (!data) return RValue_makeReal(-1.0);
 
 	Background* tileset = &runner->dataWin->bgnd.backgrounds[data->backgroundIndex];
 	return RValue_makeReal(tileset->gms2TileWidth);
@@ -14119,7 +14119,7 @@ static RValue builtin_tilemap_get_tile_height(VMContext* ctx, RValue* args, MAYB
 
 	RuntimeLayer* runtimeLayer;
     RoomLayerTilesData* data = findTilemapData(runner, RValue_toInt32(args[0]), &runtimeLayer);
-	if (!data) return RValue_makeUndefined();
+	if (!data) return RValue_makeReal(-1.0);
 
 	Background* tileset = &runner->dataWin->bgnd.backgrounds[data->backgroundIndex];
 	return RValue_makeReal(tileset->gms2TileHeight);


### PR DESCRIPTION
This fixes a division by 0 issue in Chapter 5 where gml_Object_obj_grassanim_new_Create_0 tries to get the tile size, width and height of `TILES_GRASS` instead of `TILES_GRASS_1`. It then crashes in Step_0 when it tries to divide by this, as `TILES_GRASS` doesn't exist.

This decision is backed up by the HTML5 runner and the Windows runner.

```js
function tilemap_get_tile_width( arg1) 
{
    var el = layerTilemapGetElement(yyGetInt32(arg1));
    if (el != null)
    {
    	var back = g_pBackgroundManager.GetImage(el.m_backgroundIndex);

        if(back!=null)
        {
            return back.tilewidth;
        }
    }
    return -1;

};
function tilemap_get_tile_height( arg1) 
{
    var el = layerTilemapGetElement(yyGetInt32(arg1));
    if (el != null)
    {
    	var back = g_pBackgroundManager.GetImage(el.m_backgroundIndex);

        if(back!=null)
        {
            return back.tileheight;
        }
    }
    return -1;
};
function tilemap_get_width( arg1) 
{
    var el = layerTilemapGetElement(yyGetInt32(arg1));
    if (el != null)
    {
        return el.m_mapWidth;
    }
    return -1;

};
function tilemap_get_height( arg1) 
{
    var el = layerTilemapGetElement(yyGetInt32(arg1));
    if (el != null)
    {
        return el.m_mapHeight;
    }
    return -1;
};
```

```c
// Default return is -1.0 as a double
(param_1->field0_0x0).pRefString = (_RefThing<> *)&DAT_bff0000000000000;
```