### PR TITLE
fix(runner): Remove handlePendingRoomChange from Runner_step

### DIFF
--- a/src/runner.c
+++ b/src/runner.c
@@ -3831,7 +3831,6 @@ void Runner_step(Runner* runner) {
     tickTimelines(runner);
 
     dispatchMouseEvents(runner);
-    if (runner->pendingRoom >= 0) { Runner_handlePendingRoomChange(runner); return; }
 
     // Execute Normal Step for all instances
     Runner_executeEventForAll(runner, EVENT_STEP, STEP_NORMAL);


### PR DESCRIPTION
This line was added in #181 which a PR relating to mouse support. It causes the Step event to be skipped on a room change, which causes a crash in Deltarune Chapter 5, where the Step event populates an array which is used in the Draw event. Without the step event, the array is empty and the draw event attempts to perform mod on the length of the array, crashing the game.

I think the line here was a mistake that was copy pasted in from another repo, as it's unrelated to the topic of the original PR, and apparently it passed through about 4 repos before it was merged. There are plenty of uses of handlePendingRoomChange in the platform files, so I think they're probably meant to be used there.