### PR TITLE
dup fix yay!

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -1895,12 +1895,16 @@ static void handleDup(VMContext* ctx, uint32_t instr) {
     if (IS_WAD17_OR_HIGHER(ctx) && (operand & 0x8000) != 0) {
         int32_t topNativeCount = operand & 0x7FF;
         int32_t bottomNativeCount = (operand >> 11) & 0xF;
-        int32_t topBytes = topNativeCount * typeSize;
-        int32_t bottomBytes = bottomNativeCount * typeSize;
 
-        // Convert byte counts to slot counts
-        int32_t topSlots = bytesToSlotCount(ctx, topBytes, ctx->stack.top);
-        int32_t bottomSlots = bytesToSlotCount(ctx, bottomBytes, ctx->stack.top - topSlots);
+        int32_t topSlots = topNativeCount;
+        int32_t bottomSlots = bottomNativeCount;
+
+        if (type1 != GML_TYPE_VARIABLE) {
+            int32_t topBytes = topNativeCount * typeSize;
+            int32_t bottomBytes = bottomNativeCount * typeSize;
+            topSlots = bytesToSlotCount(ctx, topBytes, ctx->stack.top);
+            bottomSlots = bytesToSlotCount(ctx, bottomBytes, ctx->stack.top - topSlots);
+        }
 
         int32_t totalSlots = topSlots + bottomSlots;
         int32_t baseIdx = ctx->stack.top - totalSlots;


### PR DESCRIPTION
When doing DUP on normal variables, we only need to set the slots as the native count, but for variables we gotta multiply it by the type size. This fixes the crash on Susie's outfit, the crash when entering Tenna's secret bonus zone, and the crash that can occur on the chapter save menu when previous attempts to fix this issue have been made.

<img width="1504" height="1248" alt="image" src="https://github.com/user-attachments/assets/f2514dab-22b8-4dd0-9599-20bcf92fd919" />
<img width="1504" height="1248" alt="image" src="https://github.com/user-attachments/assets/1250fca1-777a-4936-ba02-334703556a3c" />
