### PR TITLE
Use glGetUniformLocation instead of looping through the shader uniforms

### DIFF
--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -263,14 +263,14 @@ static GLuint linkProgram(const char* name, uint32_t vertexAttributeCount, const
     return program;
 }
 
-GLShaderUniform* findShaderUniformByName(GMLShader* shader, const char* name) {
-    repeat(shader->uniformCount, b) {
-        if (strcmp(shader->uniforms[b].name, name) == 0) {
-            return &shader->uniforms[b];
-        }
-    }
+static GLShaderUniform* getShaderUniform(GLShaderUniform* uniform, GLuint program, const char* name, GLenum type) {
+    GLint location = glGetUniformLocation(program, name);
+    if (location < 0) return NULL;
 
-    return nullptr;
+    GLShaderUniform* uniform = (GLShaderUniform*) safeCalloc(1, sizeof(GLShaderUniform));
+    uniform->location = location;
+    uniform->type = type;
+    return uniform;
 }
 
 // ===[ Batch Flush ]===
@@ -510,11 +510,11 @@ static void glInit(Renderer* renderer, DataWin* dataWin) {
 
     gl->defaultShaderProgram = defaultShader;
 
-    gl->uWorldViewProjection = findShaderUniformByName(defaultShader, "uWorldViewProjection");
-    gl->uFogColor = findShaderUniformByName(defaultShader, "uFogColor");
-    gl->uAlphaTestRef = findShaderUniformByName(defaultShader, "uAlphaTestRef");
-    gl->uAlphaTestEnabled = findShaderUniformByName(defaultShader, "uAlphaTestEnabled");
-    gl->uTexture = findShaderUniformByName(defaultShader, "uTexture");
+    gl->uWorldViewProjection = getShaderUniform(gl->uWorldViewProjection, defaultShader->shaderId, "uWorldViewProjection", GL_FLOAT_MAT4);
+    gl->uFogColor            = getShaderUniform(gl->uFogColor,            defaultShader->shaderId, "uFogColor",            GL_FLOAT_VEC4);
+    gl->uAlphaTestRef        = getShaderUniform(gl->uAlphaTestRef,        defaultShader->shaderId, "uAlphaTestRef",        GL_FLOAT);
+    gl->uAlphaTestEnabled    = getShaderUniform(gl->uAlphaTestEnabled,    defaultShader->shaderId, "uAlphaTestEnabled",    GL_BOOL);
+    gl->uTexture             = getShaderUniform(gl->uTexture,             defaultShader->shaderId, "uTexture",             GL_SAMPLER_2D);
 
     gl->gmlShaders = (GMLShader *)safeCalloc(dataWin->shdr.count, sizeof(GMLShader));
     logInfo("GL: %u Shaders Found\n", dataWin->shdr.count);
@@ -566,8 +566,8 @@ static void glInit(Renderer* renderer, DataWin* dataWin) {
 
         gl->gmlShaderCount++;
     }
-    GLShaderUniform* uAlphaTestRef = findShaderUniformByName(gl->defaultShaderProgram, "uAlphaTestRef");
-    GLShaderUniform* uFogColor = findShaderUniformByName(gl->defaultShaderProgram, "uFogColor");
+    GLShaderUniform* uAlphaTestRef = getShaderUniform(gl->uAlphaTestRef, gl->defaultShaderProgram->shaderId, "uAlphaTestRef", GL_FLOAT);
+    GLShaderUniform* uFogColor     = getShaderUniform(gl->uFogColor,     gl->defaultShaderProgram->shaderId, "uFogColor",     GL_FLOAT_VEC4);
 
     gl->alphaTestEnable = false;
     gl->alphaTestRef = 0.0f;

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -263,8 +263,8 @@ static GLuint linkProgram(const char* name, uint32_t vertexAttributeCount, const
     return program;
 }
 
-static GLShaderUniform* getShaderUniform(GLShaderUniform* uniform, GLuint program, const char* name, GLenum type) {
-    GLint location = glGetUniformLocation(program, name);
+static GLShaderUniform* getShaderUniform(GMLShader shader, const char* name, GLenum type) {
+    GLint location = glGetUniformLocation(shader->shaderId, name);
     if (location < 0) return NULL;
 
     GLShaderUniform* uniform = (GLShaderUniform*) safeCalloc(1, sizeof(GLShaderUniform));
@@ -510,11 +510,11 @@ static void glInit(Renderer* renderer, DataWin* dataWin) {
 
     gl->defaultShaderProgram = defaultShader;
 
-    gl->uWorldViewProjection = getShaderUniform(gl->uWorldViewProjection, defaultShader->shaderId, "uWorldViewProjection", GL_FLOAT_MAT4);
-    gl->uFogColor            = getShaderUniform(gl->uFogColor,            defaultShader->shaderId, "uFogColor",            GL_FLOAT_VEC4);
-    gl->uAlphaTestRef        = getShaderUniform(gl->uAlphaTestRef,        defaultShader->shaderId, "uAlphaTestRef",        GL_FLOAT);
-    gl->uAlphaTestEnabled    = getShaderUniform(gl->uAlphaTestEnabled,    defaultShader->shaderId, "uAlphaTestEnabled",    GL_BOOL);
-    gl->uTexture             = getShaderUniform(gl->uTexture,             defaultShader->shaderId, "uTexture",             GL_SAMPLER_2D);
+    gl->uWorldViewProjection = getShaderUniform(defaultShader, "uWorldViewProjection", GL_FLOAT_MAT4);
+    gl->uFogColor            = getShaderUniform(defaultShader, "uFogColor",            GL_FLOAT_VEC4);
+    gl->uAlphaTestRef        = getShaderUniform(defaultShader, "uAlphaTestRef",        GL_FLOAT);
+    gl->uAlphaTestEnabled    = getShaderUniform(defaultShader, "uAlphaTestEnabled",    GL_BOOL);
+    gl->uTexture             = getShaderUniform(defaultShader, "uTexture",             GL_SAMPLER_2D);
 
     gl->gmlShaders = (GMLShader *)safeCalloc(dataWin->shdr.count, sizeof(GMLShader));
     logInfo("GL: %u Shaders Found\n", dataWin->shdr.count);
@@ -566,8 +566,8 @@ static void glInit(Renderer* renderer, DataWin* dataWin) {
 
         gl->gmlShaderCount++;
     }
-    GLShaderUniform* uAlphaTestRef = getShaderUniform(gl->uAlphaTestRef, gl->defaultShaderProgram->shaderId, "uAlphaTestRef", GL_FLOAT);
-    GLShaderUniform* uFogColor     = getShaderUniform(gl->uFogColor,     gl->defaultShaderProgram->shaderId, "uFogColor",     GL_FLOAT_VEC4);
+    GLShaderUniform* uAlphaTestRef = getShaderUniform(gl->defaultShaderProgram, "uAlphaTestRef", GL_FLOAT);
+    GLShaderUniform* uFogColor     = getShaderUniform(gl->defaultShaderProgram, "uFogColor",     GL_FLOAT_VEC4);
 
     gl->alphaTestEnable = false;
     gl->alphaTestRef = 0.0f;

--- a/src/gl/gl_renderer.c
+++ b/src/gl/gl_renderer.c
@@ -263,7 +263,7 @@ static GLuint linkProgram(const char* name, uint32_t vertexAttributeCount, const
     return program;
 }
 
-static GLShaderUniform* getShaderUniform(GMLShader shader, const char* name, GLenum type) {
+static GLShaderUniform* getShaderUniform(GMLShader* shader, const char* name, GLenum type) {
     GLint location = glGetUniformLocation(shader->shaderId, name);
     if (location < 0) return NULL;
 


### PR DESCRIPTION
We can use glGetUniformLocation to find the uniform shader rather than just looping through it all. I think this is probably the intended way to do this, and it fixes a crash on ARM64 Windows running through Parallels VM on macOS. 

<img width="1980" height="1520" alt="image" src="https://github.com/user-attachments/assets/9dc5ab49-e744-4866-9a55-20904936eda4" />
