### PR TITLE
Fix PS3 crashing

### DIFF
--- a/src/gl_common/gl_common.c
+++ b/src/gl_common/gl_common.c
@@ -38,9 +38,16 @@ void GLCommon_endLetterboxBlit(int32_t fboWidth, int32_t fboHeight, int32_t game
     GLCommon_computeLetterbox(gameW, gameH, windowW, windowH, &sx, &sy, &ex, &ey);
 
     int32_t dstX0 = sx;
-    int32_t dstY0 = windowH - ey;
     int32_t dstX1 = ex;
+
+#ifdef PLATFORM_PS3
+    int32_t dstY0 = windowH - ey;
     int32_t dstY1 = windowH - sy;
+#else
+    int32_t dstY0 = sy;
+    int32_t dstY1 = ey;
+#endif
+
     glBlitFramebuffer(0, 0, fboWidth, fboHeight, dstX0, dstY0, dstX1, dstY1, GL_COLOR_BUFFER_BIT, GL_NEAREST);
     glBindFramebuffer(GL_FRAMEBUFFER, hostFbo);
 }

--- a/src/gl_common/gl_common.c
+++ b/src/gl_common/gl_common.c
@@ -36,7 +36,12 @@ void GLCommon_endLetterboxBlit(int32_t fboWidth, int32_t fboHeight, int32_t game
     int32_t sx, sy, ex, ey;
     glClearColor(0.0, 0.0, 0.0, 1.0); //please remove if it breaks something like borders, it was just my quick-fix for the color to not be randomly changed
     GLCommon_computeLetterbox(gameW, gameH, windowW, windowH, &sx, &sy, &ex, &ey);
-    glBlitFramebuffer(0, 0, fboWidth, fboHeight, sx, ey, ex, sy, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+
+    int32_t dstX0 = sx;
+    int32_t dstY0 = windowH - ey;
+    int32_t dstX1 = ex;
+    int32_t dstY1 = windowH - sy;
+    glBlitFramebuffer(0, 0, fboWidth, fboHeight, dstX0, dstY0, dstX1, dstY1, GL_COLOR_BUFFER_BIT, GL_NEAREST);
     glBindFramebuffer(GL_FRAMEBUFFER, hostFbo);
 }
 

--- a/src/gl_legacy/gl_legacy_renderer.c
+++ b/src/gl_legacy/gl_legacy_renderer.c
@@ -124,8 +124,10 @@ static void glApplyProjection(Renderer* renderer, const Matrix4f* viewMatrix, co
     renderer->gmlMatrices[MATRIX_PROJECTION] = projection;
     renderer->gmlMatrices[MATRIX_WORLD_VIEW] = worldView;
     renderer->gmlMatrices[MATRIX_WORLD_VIEW_PROJECTION] = worldViewProjection;
-
+    
+#ifndef PLATFORM_PS3
     Matrix4f_flipClipY(&projection);
+#endif
 
     glMatrixMode(GL_PROJECTION);
     glLoadMatrixf(projection.m);
@@ -1784,13 +1786,8 @@ static void glLegacyDrawSurface(Renderer* renderer, int32_t surfaceId, int32_t s
     // top-down GML coords -> flipped V for our bottom-up texture
     float u0 = (float) srcLeft / (float) texW;
     float u1 = (float) (srcLeft + srcWidth) / (float) texW;
-#ifndef PLATFORM_PS3
     float v0 = (float) srcTop / (float) texH;
     float v1 = (float) (srcTop + srcHeight) / (float) texH;
-#else
-    float v1 = (float) srcTop / (float) texH;
-    float v0 = (float) (srcTop + srcHeight) / (float) texH;
-#endif
 
     float r = (float) BGR_R(color) / 255.0f;
     float g = (float) BGR_G(color) / 255.0f;
@@ -1833,13 +1830,8 @@ static void glLegacyDrawSurfaceColor(Renderer* renderer, int32_t surfaceId, int3
     // top-down GML coords -> flipped V for our bottom-up texture
     float u0 = (float) srcLeft / (float) texW;
     float u1 = (float) (srcLeft + srcWidth) / (float) texW;
-#ifndef PLATFORM_PS3
     float v0 = (float) srcTop / (float) texH;
     float v1 = (float) (srcTop + srcHeight) / (float) texH;
-#else
-    float v1 = (float) srcTop / (float) texH;
-    float v0 = (float) (srcTop + srcHeight) / (float) texH;
-#endif
 
     float r1 = (float) BGR_R(color1) / 255.0f;
     float g1 = (float) BGR_G(color1) / 255.0f;


### PR DESCRIPTION
This fixes PS3 crashing by subtracting `ey` and `sy` from `windowH` in `GLCommon_endLetterBoxBlit`. I've added a PS3 specific flip in glApplyProjection, and removed two other flips in glLegacyDrawSurface and glLegacyDrawSurfaceColor.

Running with the fix:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/cb4e6cb0-a1e5-405b-9991-6af7254c56e1" />

Running without this fix gives:
```
RPCS3: RSX [0x000f174]: SIG: Thread terminated due to fatal error: Verification failed (object: 0x0)
(in file /Users/runner/work/rpcs3/rpcs3/rpcs3/Emu/RSX/VK/VKTextureCache.h:253[:6], in function 'void vk::cached_texture_section::copy_texture(vk::command_buffer &, bool)') (errno=60=Operation timed out)
qt.qpa.drawing: Display non non-main thread! Deferring to main thread
```