### PR TITLE
Better windows CI

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,19 +5,13 @@ on:
 
 jobs:
   build-glfw-windows:
-    name: Build (GLFW3 ${{ matrix.arch }})
+    name: Build (${{ matrix.arch }})
     runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: x86_64
-            target: x86_64-w64-windows-gnu
-            triplet: x86_64-w64-mingw32
-          - arch: i686
-            target: i686-w64-windows-gnu
-            triplet: i686-w64-mingw32
           - arch: arm64
             target: aarch64-w64-windows-gnu
             triplet: aarch64-w64-mingw32
@@ -100,9 +94,19 @@ jobs:
           name: butterscotch-glfw3-windows-${{ matrix.arch }}
           path: build/butterscotch.exe
 
-  build-glfw-windows-x86:
-    name: Build (GLFW2 i486)
+  build-windows:
+    name: Build (${{ matrix.arch }})
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            backend: sdl2
+            libs: SDL2_LIBS='-lmingw32 -lSDLmain -lSDL -lm -ldinput8 -ldxguid -ldxerr8 -luser32 -lgdi32 -lwinmm -limm32 -lole32 -loleaut32 -lshell32 -lsetupapi -lversion -luuid'
+          - arch: i486
+            backend: sdl1
+            libs: SDL1_LIBS='-lmingw32 -lSDLmain -lSDL -lm -luser32 -lgdi32 -lwinmm -ldxguid'
     steps:
       - uses: actions/checkout@v7
 
@@ -111,39 +115,33 @@ jobs:
         with:
           path: |
               ~/.cache/ccache
-              artifacts/windows/build/toolchain-i486
+              artifacts/windows/build/toolchain-${{ matrix.arch }}
           key: win32-artifact-${{ github.sha }}
           restore-keys: win32-artifact-
-
-      - name: Get commit info
-        id: commit-info
-        run: |
-          echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "date=$(git log -1 --format=%cd --date=short)" >> $GITHUB_OUTPUT
 
       - name: Install MinGW and dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y ccache
 
-          if [ ! -d "artifacts/windows/build/toolchain-i486" ]; then
+          if [ ! -d "artifacts/windows/build/toolchain-${{ matrix.arch }}" ]; then
             sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
-            ARCH=i486 ./artifacts/windows/build-toolchain.sh
+            ARCH=${{ matrix.arch }} ./artifacts/windows/build-toolchain.sh
           fi
 
       - name: Build
         run: |
-          PATH="$PWD/artifacts/windows/build/toolchain-i486/bin:$PATH" make \
+          PATH="$PWD/artifacts/windows/build/toolchain-${{ matrix.arch }}/bin:$PATH" make \
               NO_COLOR=1 \
               VERBOSE=1 \
-              CC='ccache i486-w64-mingw32-gcc' \
-              CFLAGS='-O3 -DNDEBUG -fomit-frame-pointer' \
-              BACKEND=glfw2 \
-              GLFW2_LIBS='-lglfw -lopengl32' \
-              EXTRALIBS='-latomic'
+              CC='ccache ${{ matrix.arch }}-w64-mingw32-gcc' \
+              CFLAGS='-O3 -DNDEBUG -flto -fomit-frame-pointer' \
+              BACKEND=${{ matrix.backend }} \
+              EXTRALIBS='-latomic' \
+              ${{ matrix.libs }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: butterscotch-glfw2-windows-x86
+          name: butterscotch-windows
           path: build/butterscotch.exe

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -122,12 +122,8 @@ jobs:
       - name: Install MinGW and dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y ccache
-
-          if [ ! -d "artifacts/windows/build/toolchain-${{ matrix.arch }}" ]; then
-            sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev
-            ARCH=${{ matrix.arch }} ./artifacts/windows/build-toolchain.sh
-          fi
+          sudo apt-get install -y ccache libgmp-dev libmpfr-dev libmpc-dev
+          ARCH=${{ matrix.arch }} ./artifacts/windows/build-toolchain.sh
 
       - name: Build
         run: |

--- a/artifacts/windows/build-toolchain.sh
+++ b/artifacts/windows/build-toolchain.sh
@@ -169,7 +169,7 @@ case $arch in
         rm -rf SDL-*
         wget -O- "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$sdl2_version.tar.gz" | tar -xz
 
-        cd "SDL-$sdl2_version"
+        cd "SDL-release-$sdl2_version"
         ./configure \
             --host="$target" \
             --prefix="$workdir/toolchain-$arch/$target" \
@@ -177,7 +177,7 @@ case $arch in
         make -j"$ncpus"
         make -j"$ncpus" install
         cd ..
-        rm -rf "SDL-$sdl2_version" &
+        rm -rf "SDL-release-$sdl2_version" &
     ;;
 esac
 

--- a/artifacts/windows/build-toolchain.sh
+++ b/artifacts/windows/build-toolchain.sh
@@ -36,16 +36,6 @@ else
     exit 1
 fi
 
-case $arch in
-    (i?86) ;;
-    (*)
-        if ! command -v cmake > /dev/null; then
-            printf 'Missing dependency: cmake\n'
-            exit 1
-        fi
-    ;;
-esac
-
 make() {
     command "$_MAKE" "$@"
 }
@@ -54,7 +44,7 @@ export PATH="$PWD/toolchain-$arch/bin:$PATH"
 
 # toolchainver should be increased if we ever make a change to the toolchain,
 # for example using a newer GCC version, and we need to invalidate the cache.
-toolchainver=2
+toolchainver=3
 if [ "$(cat "toolchain-$arch/toolchainver" 2>/dev/null)" = "$toolchainver" ]; then
     printf 'Toolchain already built! :)\n'
     exit 0
@@ -65,14 +55,17 @@ fi
 case $arch in
     (i?86)
         winnt=0x0400 # Windows NT 4.0 (We actually support lower, but this is the lowest this value is supposed to be)
+        crt=crtdll
     ;;
     (x86_64)
         winnt=0x0502 # Windows XP x64 edition / Server 2003
+        crt=msvcrt
     ;;
     (arm64|aarch64)
         printf 'aarch64 builds are currently unsupported.\n'
         exit 1
-        # winnt=0x0A00 # Windows 10
+        winnt=0x0A00 # Windows 10
+        crt=ucrt
     ;;
     (*)
         printf 'Unknown architecture!\n'
@@ -106,7 +99,7 @@ cd "mingw-w64-v$mingw_version/mingw-w64-headers"
     --host="$target" \
     --prefix="$workdir/toolchain-$arch/$target" \
     --with-default-win32-winnt="$winnt" \
-    --with-default-msvcrt=crtdll
+    --with-default-msvcrt="$crt"
 make -j"$ncpus" install
 cd ../..
 
@@ -142,7 +135,7 @@ cd "mingw-w64-v$mingw_version/mingw-w64-crt"
     --host="$target" \
     --prefix="$workdir/toolchain-$arch/$target" \
     --with-default-win32-winnt="$winnt" \
-    --with-default-msvcrt=crtdll
+    --with-default-msvcrt="$crt"
 make -j1
 make -j1 install
 cd ../..
@@ -154,16 +147,39 @@ make -j"$ncpus" install-strip
 cd ../..
 rm -rf "gcc-$gcc_version" &
 
-glfw2_version='2.7.9'
-rm -rf glfw-*
-wget -O- "https://github.com/glfw/glfw-legacy/archive/refs/tags/$glfw2_version.tar.gz" | tar -xz
+case $arch in
+    (i?86)
+        sdl1_version='39e1580a7d2f8c09521338108c2a94019e37798e'
+        rm -rf SDL-1.2-*
+        wget -O- "https://github.com/libsdl-org/SDL-1.2/archive/$sdl1_version.tar.gz" | tar -xz
 
-cd "glfw-legacy-$glfw2_version"
-make -j"$ncpus" cross-mgw-install \
-    TARGET="$target-" \
-    PREFIX="$workdir/toolchain-$arch/$target"
-cd ..
-rm -rf "glfw-legacy-$glfw2_version" &
+        cd "SDL-1.2-$sdl1_version"
+        ./configure \
+            --host="$target" \
+            --prefix="$workdir/toolchain-$arch/$target" \
+            --disable-shared \
+            --disable-stdio-redirect
+        make -j"$ncpus"
+        make -j"$ncpus" install
+        cd ..
+        rm -rf "SDL-1.2-$sdl1_version" &
+    ;;
+    (x86_64|arm64|aarch64)
+        sdl2_version='2.32.10'
+        rm -rf SDL-*
+        wget -O- "https://github.com/libsdl-org/SDL/archive/refs/tags/release-$sdl2_version.tar.gz" | tar -xz
+
+        cd "SDL-$sdl2_version"
+        ./configure \
+            --host="$target" \
+            --prefix="$workdir/toolchain-$arch/$target" \
+            --disable-shared
+        make -j"$ncpus"
+        make -j"$ncpus" install
+        cd ..
+        rm -rf "SDL-$sdl2_version" &
+    ;;
+esac
 
 printf '%s' "$toolchainver" > "toolchain-$arch/toolchainver"
 wait

--- a/artifacts/windows/build-toolchain.sh
+++ b/artifacts/windows/build-toolchain.sh
@@ -158,7 +158,8 @@ case $arch in
             --host="$target" \
             --prefix="$workdir/toolchain-$arch/$target" \
             --disable-shared \
-            --disable-stdio-redirect
+            --disable-stdio-redirect \
+            --disable-threads
         make -j"$ncpus"
         make -j"$ncpus" install
         cd ..


### PR DESCRIPTION
x86_64 version *should* now work on as low as windows XP x64 edition, (unless SDL 2 doesn't support it).
No more i686 version, it was redundant.
llvm-mingw is only used for arm64 now.